### PR TITLE
Improve file reading

### DIFF
--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -33,12 +33,19 @@ py::buffer_info vecarray_buffer(std::vector<std::array<T, n>> &v) {
     );
 }
 
+template<typename T>
+py::buffer_info vector_buffer(std::vector<T> &v) {
+    return py::buffer_info(&v[0], sizeof(T), py::format_descriptor<T>::format(), 1, { v.size() }, { sizeof(T) });
+}
+
+
 PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::PointList>(m, "PointVector", py::buffer_protocol())
         .def_buffer(&vecarray_buffer<double, 3>);
     py::bind_vector<rasputin::FaceList>(m, "FaceVector", py::buffer_protocol())
         .def_buffer(&vecarray_buffer<int, 3>);
-    py::bind_vector<rasputin::ScalarList>(m, "ScalarVector");
+    py::bind_vector<rasputin::ScalarList>(m, "ScalarVector", py::buffer_protocol())
+        .def_buffer(&vector_buffer<double>);
 
     py::bind_vector<std::vector<int>>(m, "IntVector");
     py::bind_vector<std::vector<std::vector<int>>>(m, "ShadowVector");

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -66,7 +66,11 @@ PYBIND11_MODULE(triangulate_dem, m) {
     ).def("compute_shadows", &rasputin::compute_shadows,
           "Compute shadows for a series of times and ray directions."
     ).def("surface_normals", &rasputin::surface_normals,
-            "Compute surface normals for all faces in the mesh.")
+            "Compute surface normals for all faces in the mesh."
+    ).def("orient_tin", &rasputin::orient_tin,
+            "Orients all triangles in the TIN and returns their surface normals."
+    ).def("compute_slopes", &rasputin::compute_slopes,
+            "computes slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
     .def("rasterdata_to_pointvector",
         [] (py::array_t<double> array, double x0, double y0, double x1, double y1) {
         auto buffer = array.request();

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -21,29 +21,28 @@ PYBIND11_MAKE_OPAQUE(rasputin::PointList);
 PYBIND11_MAKE_OPAQUE(rasputin::FaceList);
 PYBIND11_MAKE_OPAQUE(rasputin::ScalarList);
 
-
-// templated buffer protocol definitions to reduce code duplication
 template<typename T, std::size_t n>
-py::buffer_info vecarray_buffer (std::vector<std::array<T, n>> &v) {
-        return py::buffer_info(
-            &v[0],                                        /* Pointer to buffer */
-            sizeof(T),                                    /* Size of one scalar */
-            py::format_descriptor<T>::format(),           /* Python struct-style format descriptor */
-            2,                                            /* Number of dimensions */
-            std::vector<std::size_t> { v.size(), n },     /* Buffer dimensions */
-            { sizeof(T) * n, sizeof(T) }                  /* Strides (in bytes) for each index */
-        );
+py::buffer_info vecarray_buffer(std::vector<std::array<T, n>> &v) {
+    return py::buffer_info(
+        &v[0],                                        /* Pointer to buffer */
+        sizeof(T),                                    /* Size of one scalar */
+        py::format_descriptor<T>::format(),           /* Python struct-style format descriptor */
+        2,                                            /* Number of dimensions */
+        std::vector<std::size_t> { v.size(), n },     /* Buffer dimensions */
+        { sizeof(T) * n, sizeof(T) }                  /* Strides (in bytes) for each index */
+    );
 }
 
 PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::PointList>(m, "PointVector", py::buffer_protocol())
-      .def_buffer(&vecarray_buffer<double, 3>);
+        .def_buffer(&vecarray_buffer<double, 3>);
     py::bind_vector<rasputin::FaceList>(m, "FaceVector", py::buffer_protocol())
-      .def_buffer(&vecarray_buffer<int, 3>);
-
+        .def_buffer(&vecarray_buffer<int, 3>);
     py::bind_vector<rasputin::ScalarList>(m, "ScalarVector");
+
     py::bind_vector<std::vector<int>>(m, "IntVector");
     py::bind_vector<std::vector<std::vector<int>>>(m, "ShadowVector");
+
     m.def("lindstrom_turk_by_size",
           [] (const rasputin::PointList& raster_coordinates, size_t result_mesh_size) {
               return rasputin::make_tin(raster_coordinates,
@@ -51,39 +50,33 @@ PYBIND11_MODULE(triangulate_dem, m) {
                                         SMS::LindstromTurk_placement<CGAL::Mesh>(),
                                         SMS::LindstromTurk_cost<CGAL::Mesh>());
           },
-          "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the size threshold."
-    ).def("lindstrom_turk_by_ratio",
-          [] (const rasputin::PointList& raster_coordinates, double ratio) {
-              return rasputin::make_tin(raster_coordinates,
-                                        SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
-                                        SMS::LindstromTurk_placement<CGAL::Mesh>(),
-                                        SMS::LindstromTurk_cost<CGAL::Mesh>());
-          },
-          "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold."
-    ).def("compute_shadow",
-          &rasputin::compute_shadow,
-          "Compute shadows for given sun ray direction."
-    ).def("compute_shadows", &rasputin::compute_shadows,
-          "Compute shadows for a series of times and ray directions."
-    ).def("surface_normals", &rasputin::surface_normals,
-            "Compute surface normals for all faces in the mesh."
-    ).def("orient_tin", &rasputin::orient_tin,
-            "Orients all triangles in the TIN and returns their surface normals."
-    ).def("compute_slopes", &rasputin::compute_slopes,
-            "computes slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
-    .def("rasterdata_to_pointvector",
-        [] (py::array_t<double> array, double x0, double y0, double x1, double y1) {
-        auto buffer = array.request();
-        int m = buffer.shape[0], n = buffer.shape[1];
-        double* ptr = (double*) buffer.ptr;
+          "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the size threshold.")
+        .def("lindstrom_turk_by_ratio",
+             [] (const rasputin::PointList& raster_coordinates, double ratio) {
+                 return rasputin::make_tin(raster_coordinates,
+                                           SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
+                                           SMS::LindstromTurk_placement<CGAL::Mesh>(),
+                                           SMS::LindstromTurk_cost<CGAL::Mesh>());
+             },
+            "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.")
+        .def("compute_shadow", &rasputin::compute_shadow, "Compute shadows for given sun ray direction.")
+        .def("compute_shadows", &rasputin::compute_shadows, "Compute shadows for a series of times and ray directions.")
+        .def("surface_normals", &rasputin::surface_normals, "Compute surface normals for all faces in the mesh.")
+        .def("orient_tin", &rasputin::orient_tin, "Orients all triangles in the TIN and returns their surface normals.")
+        .def("compute_slopes", &rasputin::compute_slopes,"computes slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
+        .def("rasterdata_to_pointvector",
+             [] (py::array_t<double> array, double x0, double y0, double x1, double y1) {
+                 auto buffer = array.request();
+                 int m = buffer.shape[0], n = buffer.shape[1];
+                 double* ptr = (double*) buffer.ptr;
 
-        double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
+                 double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
 
-        rasputin::PointList raster_coordinates;
-        raster_coordinates.reserve(m*n);
-        for (std::size_t i = 0; i < m; ++i)
-          for (std::size_t j = 0; j < n; ++j)
-            raster_coordinates.push_back(std::array<double, 3>{x0 + j*dx, y1 - i*dy, ptr[i*n + j]});
-        return raster_coordinates;
-        }, "Pointvector from raster data");
+                 rasputin::PointList raster_coordinates;
+                 raster_coordinates.reserve(m*n);
+                 for (std::size_t i = 0; i < m; ++i)
+                     for (std::size_t j = 0; j < n; ++j)
+                         raster_coordinates.push_back(std::array<double, 3>{x0 + j*dx, y1 - i*dy, ptr[i*n + j]});
+                 return raster_coordinates;
+            }, "Pointvector from raster data");
 }

--- a/src/rasputin/calculate.py
+++ b/src/rasputin/calculate.py
@@ -6,10 +6,9 @@ from rasputin import triangulate_dem
 def compute_shade(*,
                   pts: triangulate_dem.PointVector,
                   faces: triangulate_dem.FaceVector,
-                  sun_ray: List[float],
-                  time: int) -> List[Tuple[int, np.ndarray]]:
+                  sun_ray: List[float]) -> np.ndarray:
     assert len(sun_ray) == 3
     shades = triangulate_dem.compute_shadow(pts, faces, sun_ray)
     has_shades = np.zeros(len(faces), dtype='int')
     has_shades[shades] = 1
-    return [(time, has_shades)]
+    return has_shades

--- a/src/rasputin/geo_tiff_reader.py
+++ b/src/rasputin/geo_tiff_reader.py
@@ -2,12 +2,12 @@ import sys
 from pathlib import Path
 import argparse
 from logging import getLogger
-from rasputin.writer import write_mesh
+from rasputin.writer import write
 from rasputin.reader import read_raster_file
 from rasputin.calculate import compute_shade
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio
 from rasputin.triangulate_dem import lindstrom_turk_by_size
-from rasputin.triangulate_dem import surface_normals
+from rasputin.triangulate_dem import surface_normals, orient_tin, compute_slopes
 
 
 def geo_tiff_reader():
@@ -15,42 +15,55 @@ def geo_tiff_reader():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("input", type=str, metavar="FILENAME")
     arg_parser.add_argument("-output", type=str, default="output.off", help="Surface mesh file name")
-    arg_parser.add_argument("-start_x", type=int, default=0, help="Start index in x-direction")
-    arg_parser.add_argument("-stop_x", type=int, default=None, help="Stop index in x-direction")
-    arg_parser.add_argument("-start_y", type=int, default=0, help="Start index in y-direction")
-    arg_parser.add_argument("-stop_y", type=int, default=None, help="Stop index in y-direction")
+    arg_parser.add_argument("-x0", type=float, default=None, help="Start coordinate in x-direction")
+    arg_parser.add_argument("-x1", type=float, default=None, help="Stop coordinate in x-direction")
+    arg_parser.add_argument("-y0", type=float, default=None, help="Start coordinate in y-direction")
+    arg_parser.add_argument("-y1", type=float, default=None, help="Stop coordinate in y-direction")
     arg_parser.add_argument("-sun_x", type=float, help="Sun ray x component")
     arg_parser.add_argument("-sun_y", type=float, help="Sun ray y component")
     arg_parser.add_argument("-sun_z", type=float, help="Sun ray z component")
-    arg_parser.add_argument("-n", type=bool, default=False, help="Compute surface normals")
+    arg_parser.add_argument("-n", action="store_true", help="Compute surface normals")
+    arg_parser.add_argument("-slope", action="store_true", help="Compute slope")
     arg_parser.add_argument("-loglevel", type=int, default=1, help="Verbosity")
     group = arg_parser.add_mutually_exclusive_group(required=True)
     group.add_argument("-ratio", type=float, help="Edge ratio between original meshed raster and result")
-    group.add_argument("-size", type=float, help="Number of edges in the generated surface mesh")
+    group.add_argument("-size", type=int, help="Number of edges in the generated surface mesh")
+
     res = arg_parser.parse_args(sys.argv[1:])
     logger.setLevel(res.loglevel)
+
+    # Read from raster
     raster_coords, info = read_raster_file(filepath=Path(res.input),
-                                           start_x=res.start_x,
-                                           stop_x=res.stop_x,
-                                           start_y=res.start_y,
-                                           stop_y=res.stop_y)
+                                           x0=res.x0,
+                                           y0=res.y0,
+                                           x1=res.x1,
+                                           y1=res.y1)
     logger.debug(f"Original: {len(raster_coords)}")
     logger.critical(info)
     if res.ratio:
         pts, faces = lindstrom_turk_by_ratio(raster_coords, res.ratio)
     else:
         pts, faces = lindstrom_turk_by_size(raster_coords, res.size)
-    logger.debug(f"Result: {len(raster_coords)}")
+    logger.debug(f"Result: {len(pts)}")
+
+    # Compute normals and re-orient before shadow computation
+    normals = orient_tin(pts, faces)
+
+    # Compute additional fields
+    fields = {}
+
     if res.sun_x is not None or res.sun_y is not None or res.sun_z is not None:
         assert res.sun_x is not None
         assert res.sun_y is not None
         assert res.sun_z is not None
-        shade_field = compute_shade(pts=pts, faces=faces, sun_ray=[res.sun_x, res.sun_y, res.sun_z], time=0)
-    else:
-        shade_field = []
-    output_path = Path(res.output)
+        fields["shade"] = compute_shade(pts=pts, faces=faces, sun_ray=[res.sun_x, res.sun_y, res.sun_z])
+
     if res.n:
-        normals = surface_normals(pts, faces)
-        for normal in normals:
-            print(list(normal))
-    write_mesh(pts=pts, faces=faces, shades=shade_field, filepath=output_path)
+        fields["surface_normal"] = normals
+
+    if res.slope:
+        slopes = compute_slopes(normals)
+        fields["slope"] = slopes
+
+    output_path = Path(res.output)
+    write(pts=pts, faces=faces, filepath=output_path, fields=fields)

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -144,9 +144,9 @@ class GeoKeysParser(object):
 
 
     NOTE:
-    This class is incomplete and many GeoKeys are not handled. However, extending the class
-    with new handlers or expanding existing ones should be mostly straight forward, but some
-    care needs to be taken in order to support geographical systems not having degrees as unit.
+    This class is incomplete and many GeoKeys are not handled. Extending the class with new handlers
+    or expanding existing ones should be mostly straight forward, but some care needs to be taken in
+    order to support angular units that are not degrees.
     """
     def __init__(self, geokeys):
         self.geokeys = geokeys
@@ -181,8 +181,14 @@ class GeoKeysParser(object):
                 else:
                     self.dict[name] = val
 
+        # Report unhandled GeoKeys
+        logger = getLogger()
+        logger.debug(f"Unhandled GeoKeys: {unhandled}")
 
     def to_proj4(self) -> str:
+        """
+        Returns a string to be used with pyproj.
+        """
         epsg = self.dict.get("EPSG")
         if epsg is not None:
             # The EPSG code completely specifies the projection. No more parameters needed
@@ -194,7 +200,7 @@ class GeoKeysParser(object):
 
         # Add no_defs to proj4 string to avoid use of default values.
         # Pyproj should raise an error for incomplete specification (e.g. missing ellps)
-        # Howerer, inconsistentencise ignored (e.g. when 'b' and 'f' are both provided)
+        # Howerer, inconsistentencise may be ignored (e.g. when 'b' and 'rf' are both provided)
         proj4_str += " +no_defs"
 
         return proj4_str
@@ -278,7 +284,7 @@ class GeoKeysParser(object):
 
 
 def identify_projection(image: TiffImageFile) -> str:
-    geokeys = extract_geo_keys(image)
+    geokeys = extract_geo_keys(image=image)
     return GeoKeysParser(geokeys).to_proj4()
 
 

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -134,7 +134,7 @@ def extract_geo_keys(*, image: TiffImageFile) -> Dict[str, Any]:
     return geo_keys
 
 
-class GeoKeysParser(object):
+class GeoKeysInterpreter(object):
     """
     This class provides functionality for converting a dict of GeoTIFF keys
     into a useable PROJ.4 projection specification.
@@ -142,7 +142,7 @@ class GeoKeysParser(object):
     The string output can be used with pyproj to do coordinate transformations:
 
         import pyproj
-        proj_str = GeoKeyParser(geokeys).to_proj4()
+        proj_str = GeoKeyInterpreter(geokeys).to_proj4()
         proj = pyproj.Proj(proj_str)
 
     NOTE:
@@ -153,9 +153,9 @@ class GeoKeysParser(object):
     def __init__(self, geokeys):
         self.geokeys = geokeys
         self.dict = dict()
-        self.parse()
+        self.interpret()
 
-    def parse(self):
+    def interpret(self):
         # Try to extract a proj4 keyword argument for each (key, value) pair in the geokeys
         ignored_keys = []
         for (geokey_name, geokey_value) in self.geokeys.items():
@@ -277,7 +277,7 @@ class GeoKeysParser(object):
 
 def identify_projection(*, image: TiffImageFile) -> str:
     geokeys = extract_geo_keys(image=image)
-    return GeoKeysParser(geokeys).to_proj4()
+    return GeoKeysInterpreter(geokeys).to_proj4()
 
 
 def img_slice(img, start_i, stop_i, start_j, stop_j):

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Dict, Any, Optional
 from enum import Enum
 from PIL import Image
+from PIL.TiffImagePlugin import TiffImageFile
 import json
 from itertools import islice
 import numpy as np
@@ -9,33 +10,114 @@ from logging import getLogger
 from rasputin import triangulate_dem
 
 
-class AsciiGeoKeys(Enum):
-    GTCitationGeoKey = 1026
-    GeogCitationGeoKey = 2049
+class KeyValueTags(Enum):
+    # Parameter value types:
+    #    'short'  values are stored in the geokey directory
+    #    'double'                   in tag 34736 at given offset
+    #    'ascii'                    in tag 34737 at offset:offset+count
+    GeoShortParamsTag = 0
+    GeoDoubleParamsTag = 34736
+    GeoAsciiParamsTag = 34737
 
 
-class CodedGeoKeys(Enum):
+class GeoKeys(Enum):
+    # Configuration keys
     GTModelTypeGeoKey = 1024
     GTRasterTypeGeoKey = 1025
+    GTCitationGeoKey = 1026
+
+    # Geographic CS parameter keys
+    GeographicTypeGeoKey = 2048
+    GeogCitationGeoKey = 2049
+    GeogGeodeticDatumGeoKey = 2050
+    GeogPrimeMeridianGeoKey = 2051
+    GeogPrimeMeridianLongGeoKey = 2061
+    GeogLinearUnitSizeGeoKey = 2053
     GeogAngularUnitsGeoKey = 2054
+    GeogAngularUnitSizeGeoKey = 2055
+    GeogEllipsoidGeoKey = 2056
+    GeogSemiMajorAxisGeoKey = 2057
+    GeogSemiMinorAxisGeoKey = 2058
+    GeogInvFlatteningGeoKey = 2059
+    GeogAzimuthUnitsGeoKey = 2060
+
+    # Projected CS parameters keys
     ProjectedCSTypeGeoKey = 3072
+    PCSCitationGeoKey = 3073
+
+    # Projection definition keys
+    ProjectionGeoKey = 3074
+    ProjCoordTransGeoKey = 3075
     ProjLinearUnitsGeoKey = 3076
+    ProjLinearUnitSizeGeoKey = 3077
+    ProjStdParallel1GeoKey = 3078
+    ProjStdParallel2GeoKey = 3079
+    ProjNatOriginLongGeoKey = 3080
+    ProjNatOriginLatGeoKey = 3081
+    ProjFalseEastingGeoKey = 3082
+    ProjFalseNorthingGeoKey = 3083
+    ProjFalseOriginLongGeoKey = 3084
+    ProjFalseOriginLatGeoKey = 3085
+    ProjFalseOriginEastingGeoKey = 3086
+    ProjFalseOriginNorthingGeoKey = 3087
+    ProjCenterLongGeoKey = 3088
+    ProjCenterLatGeoKey = 3089
+    ProjCenterEastingGeoKey = 3090
+    ProjCenterNorthingGeoKey = 3091 # Incorrectly named in document
+    ProjScaleAtNatOriginGeoKey = 3092
+    ProjScaleAtCenterGeoKey = 3093
+    ProjAzimuthAngleGeoKey = 3094
+    ProjStraightVertPoleLongGeoKey = 3095
 
 
-def extract_geo_keys(*, named_tags: dict) -> Dict[str, Any]:
-    geo_key_directory = np.array(named_tags["GeoKeyDirectoryTag"]).reshape(-1, 4)
-    geo_keys = geo_key_directory[:, 0]
-    info = {}
-    for k in AsciiGeoKeys:
-        if k.value in geo_keys:
-            row = geo_key_directory[np.where(k.value == geo_keys)].flatten()
-            if row[1] == 34737:
-                info[k.name] = named_tags["GeoAsciiParamsTag"][0][row[3]: row[3] + row[2]]
-    for k in CodedGeoKeys:
-        if k.value in geo_keys:
-            row = geo_key_directory[np.where(k.value == geo_keys)].flatten()
-            info[k.name] = row[3]
-    return info
+def extract_geo_keys(*, image: TiffImageFile) -> Dict[str, Any]:
+    """ Extract GeoKeys from image and return as Python dictionary. """
+
+    # Using .tag_v2 instead of legacy .tag
+    image_tags = image.tag_v2
+    try:
+        GeoKeyDirectory = np.asarray(image_tags[34735], dtype="ushort").reshape((-1,4))
+    except KeyError:
+        raise RuntimeError("Image is missing GeoKeyDirectory required by GeoTiff v1.0.")
+
+    Header = GeoKeyDirectory[0,:]
+    KeyDirectoryVersion = Header[0]
+    KeyRevision = (Header[1], Header[2])
+    NumberOfKeys = Header[3]
+
+    assert KeyDirectoryVersion == 1 # Only existing version
+    assert len(GeoKeyDirectory) == NumberOfKeys + 1
+
+    # Read all the geokey fields
+    geo_keys = {}
+    for (key_id, location, count, value_offset) in GeoKeyDirectory[1:]:
+        key_name = GeoKeys(key_id).name
+
+        if KeyValueTags(location) == KeyValueTags.GeoShortParamsTag:
+            # Short values are stored in value_offset field in the directory
+            key_value = value_offset
+
+            # Translate special integer values for readability:
+            if key_value == 0:
+                key_value = "undefined"
+
+            elif key_value == 32767:
+                key_value = "user-defined"
+
+        if KeyValueTags(location) == KeyValueTags.GeoDoubleParamsTag:
+            tiff_tag = KeyValueTags.GeoDoubleParamsTag.value
+            offset = value_offset
+            key_value = image_tags[tiff_tag][offset]
+
+        if KeyValueTags(location) == KeyValueTags.GeoAsciiParamsTag:
+            tiff_tag = KeyValueTags.GeoAsciiParamsTag.value
+            offset = value_offset
+            ascii_val = image_tags[tiff_tag][offset:offset + count]
+            key_value = ascii_val.replace("|", "\n").strip()
+
+        geo_keys[key_name] = key_value
+
+    return geo_keys
 
 
 def img_slice(img, start_i, stop_i, start_j, stop_j):

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -277,8 +277,8 @@ class GeoKeysParser(object):
         return update
 
 
-def get_projection(image: TiffImageFile) -> str:
-    geokeys = extract_geokeys(image)
+def identify_projection(image: TiffImageFile) -> str:
+    geokeys = extract_geo_keys(image)
     return GeoKeysParser(geokeys).to_proj4()
 
 

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -209,7 +209,7 @@ class GeoKeysParser(object):
     @staticmethod
     def _GeogInvFlatteningGeoKey(value):
         if np.isscalar(value):
-            return {"f": float(value)}
+            return {"rf": float(value)}
 
 
     @staticmethod

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -2,6 +2,7 @@ from typing import Tuple, Dict, Any, Optional
 from enum import Enum
 from PIL import Image
 from PIL.TiffImagePlugin import TiffImageFile
+import pyproj
 import json
 import re
 from itertools import islice
@@ -307,41 +308,64 @@ def img_slice(img, start_i, stop_i, start_j, stop_j):
 
 def read_raster_file(*,
                      filepath: Path,
-                     start_x: int,
-                     stop_x: Optional[int],
-                     start_y: int,
-                     stop_y: Optional[int]) -> Tuple[triangulate_dem.PointVector, Dict[str, Any]]:
+                     x0: Optional[float] = None,
+                     x1: Optional[float] = None,
+                     y0: Optional[float] = None,
+                     y1: Optional[float] = None) -> Tuple[triangulate_dem.PointVector, Dict[str, Any]]:
     logger = getLogger()
     logger.debug(f"Reading raster file {filepath}")
     assert filepath.exists()
-    with Image.open(filepath) as image:
-        if None in [stop_x, stop_y]:
-            m, n = image.size
-            if stop_x is None:
-                stop_x = n
-            if stop_y is None:
-                stop_y = m
-        count = (stop_x - start_x)*(stop_y - start_y)
+    if x0 and x1: assert x0 < x1
+    if y0 and y1: assert y0 < y1
 
+    with Image.open(filepath) as image:
+        # Determine image extents
+        m, n = image.size
         model_pixel_scale = image.tag_v2.get(GeoTiffTags.ModelPixelScaleTag.value)
         model_tie_point = image.tag_v2.get(GeoTiffTags.ModelTiePointTag.value)
         info = extract_geo_keys(image=image)
 
-        d = np.fromiter(img_slice(image, start_y, stop_y, start_x, stop_x), dtype="float", count=count).reshape(stop_y - start_y, -1)
-        #d = np.array(image.getdata()).reshape(image.size[0], image.size[1])[start_x:stop_x, start_y:stop_y]
+        # Use pixel coordinates if image does not define an affine transformation
+        # This should only happen if the image is not a GeoTIFF
+        dx = dy = 1.0
+        if model_pixel_scale:
+            dx, dy, _ = model_pixel_scale
 
-    dx = dy = 1.0
-    if model_pixel_scale:
-        dx, dy, _ = model_pixel_scale
+        xt = yt = 0.0
+        it = jt = 0
+        if model_tie_point:
+            jt, it, _, xt, yt, _ = model_tie_point
 
-    x0 = y0 = 0.0
-    I = J = 0
-    if model_tie_point:
-        J, I, _, x0, y0, _ = model_tie_point
+        # Determine image coordinates, assuming here that the tie point is associated with pixel center.
+        # Otherwise, coordinates should be shiftet half pixel size in both directions
+        X0, X1 = xt - jt * dx, xt + (n -1 - jt) * dx
+        Y1, Y0 = yt + it * dy, yt - (m -1 - it) * dy
 
-    raster_coordinates = triangulate_dem.PointVector()
-    for (i, j), h in np.ndenumerate(d):
-        raster_coordinates.append([x0 + (start_x + j - J)*dx, y0 - (start_y + i - I)*dy, h])
+        if x0 is None: x0 = X0
+        if x1 is None: x1 = X1
+        if y0 is None: y0 = Y0
+        if y1 is None: y1 = Y1
+
+        # Identify pixel coordinates of view window extended to align with pixels
+        j0 = max(int(np.floor((x0 - X0) / dx)), 0)
+        j1 = min(int(np.ceil((x1 - X0) / dx)), m-1)
+        i0 = max(int(np.floor((Y1 - y1) / dy)), 0)
+        i1 = min(int(np.ceil((Y1 - y0) / dy)), n-1)
+
+        if j1 <= 0 or i1 <= 0 or i0 >= n or j0 >= m:
+            # Empty view window, raise an error since PIL does not
+            raise ValueError("Selected view window is outside of image bounds")
+
+        d = np.asarray(image.crop(box=(j0, i0, j1+1, i1+1)))
+
+
+    # Get the actual coordinates of returned view window
+    x0d, x1d = X0 + j0 * dx, X0 + j1 * dx
+    y0d, y1d = Y1 - i1 * dy, Y1 - i0 * dy
+
+    # Call c++ function to populate pointvector
+    raster_coordinates = triangulate_dem.rasterdata_to_pointvector(d, x0d, y0d, x1d, y1d)
+
     logger.debug("Done")
     return raster_coordinates, info
 

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -347,15 +347,15 @@ def read_raster_file(*,
 
         # Identify pixel coordinates of view window extended to align with pixels
         j0 = max(int(np.floor((x0 - X0) / dx)), 0)
-        j1 = min(int(np.ceil((x1 - X0) / dx)), m - 1)
+        j1 = min(int(np.ceil((x1 - X0) / dx)), m)
         i0 = max(int(np.floor((Y1 - y1) / dy)), 0)
-        i1 = min(int(np.ceil((Y1 - y0) / dy)), n - 1)
+        i1 = min(int(np.ceil((Y1 - y0) / dy)), n)
 
         if j1 <= 0 or i1 <= 0 or i0 >= n or j0 >= m:
             # Empty view window, raise an error since PIL does not
             raise ValueError("Selected view window is outside of image bounds")
 
-        d = image.crop(box=(j0, i0, j1 + 1, i1 + 1))
+        d = image.crop(box=(j0, i0, j1, i1))
 
     # Get the actual coordinates of returned view window
     x0d, x1d = X0 + j0 * dx, X0 + j1 * dx

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -362,7 +362,7 @@ def read_raster_file(*,
             # Empty view window, raise an error since PIL does not
             raise ValueError("Selected view window is outside of image bounds")
 
-        d = np.asarray(image.crop(box=(j0, i0, j1+1, i1+1)))
+        d = image.crop(box=(j0, i0, j1+1, i1+1))
 
 
     # Get the actual coordinates of returned view window

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -11,10 +11,12 @@ from pathlib import Path
 from logging import getLogger
 from rasputin import triangulate_dem
 
+
 class GeoTiffTags(Enum):
     ModelTiePointTag = 33922
     ModelPixelScaleTag = 33550
     GeoKeyDirectoryTag = 34735
+
 
 class KeyValueTags(Enum):
     # Parameter value types:
@@ -69,7 +71,7 @@ class GeoKeys(Enum):
     ProjCenterLongGeoKey = 3088
     ProjCenterLatGeoKey = 3089
     ProjCenterEastingGeoKey = 3090
-    ProjCenterNorthingGeoKey = 3091 # Incorrectly named in document
+    ProjCenterNorthingGeoKey = 3091  # Incorrectly named in document
     ProjScaleAtNatOriginGeoKey = 3092
     ProjScaleAtCenterGeoKey = 3093
     ProjAzimuthAngleGeoKey = 3094
@@ -87,16 +89,17 @@ def extract_geo_keys(*, image: TiffImageFile) -> Dict[str, Any]:
     image_tags = image.tag_v2
     geo_key_tag = GeoTiffTags.GeoKeyDirectoryTag.value
     try:
-        GeoKeyDirectory = np.asarray(image_tags[geo_key_tag], dtype="ushort").reshape((-1,4))
+        GeoKeyDirectory = np.asarray(image_tags[geo_key_tag],
+                                     dtype="ushort").reshape((-1, 4))
     except KeyError:
         raise RuntimeError("Image is missing GeoKeyDirectory required by GeoTiff v1.0.")
 
-    Header = GeoKeyDirectory[0,:]
+    Header = GeoKeyDirectory[0, :]
     KeyDirectoryVersion = Header[0]
     KeyRevision = (Header[1], Header[2])
     NumberOfKeys = Header[3]
 
-    assert KeyDirectoryVersion == 1 # Only existing version
+    assert KeyDirectoryVersion == 1  # Only existing version
     assert len(GeoKeyDirectory) == NumberOfKeys + 1
 
     # Read all the geokey fields
@@ -142,7 +145,6 @@ class GeoKeysParser(object):
         proj_str = GeoKeyParser(geokeys).to_proj4()
         proj = pyproj.Proj(proj_str)
 
-
     NOTE:
     This class is incomplete and many GeoKeys are not handled. Extending the class with new handlers
     or expanding existing ones should be mostly straight forward, but some care needs to be taken in
@@ -153,17 +155,16 @@ class GeoKeysParser(object):
         self.dict = dict()
         self.parse()
 
-
     def parse(self):
         # Try to extract a proj4 keyword argument for each (key, value) pair in the geokeys
-        unhandled = []
+        ignored_keys = []
         for (geokey_name, geokey_value) in self.geokeys.items():
             # Get handler
             try:
                 handler = getattr(self, f"_{geokey_name}")
             except AttributeError:
-                # Skip the GeoKey since no handler defined
-                unhandled.append(geokey_name)
+                # Skip the GeoKey when no handler defined
+                ignored_keys.append(geokey_name)
                 continue
 
             # Get a dict update from handler
@@ -181,9 +182,8 @@ class GeoKeysParser(object):
                 else:
                     self.dict[name] = val
 
-        # Report unhandled GeoKeys
         logger = getLogger()
-        logger.debug(f"Unhandled GeoKeys: {unhandled}")
+        logger.debug(f"Ignored GeoKeys: {ignored_keys}")
 
     def to_proj4(self) -> str:
         """
@@ -200,41 +200,35 @@ class GeoKeysParser(object):
 
         # Add no_defs to proj4 string to avoid use of default values.
         # Pyproj should raise an error for incomplete specification (e.g. missing ellps)
-        # Howerer, inconsistentencise may be ignored (e.g. when 'b' and 'rf' are both provided)
+        # Howerer, inconsistentencies may be ignored (e.g. when 'b' and 'rf' are both provided)
         proj4_str += " +no_defs"
 
         return proj4_str
-
 
     @staticmethod
     def _ProjectedCSTypeGeoKey(value):
         if _isinteger(value) and 20000 <= value <= 32760:
             return {"EPSG": value}
 
-
     @staticmethod
     def _GeoGraphicTypeGeo(value):
         if _isinteger(value) and 4000 <= value < 5000:
             return {"EPSG": value}
-
 
     @staticmethod
     def _GeogInvFlatteningGeoKey(value):
         if np.isscalar(value):
             return {"rf": float(value)}
 
-
     @staticmethod
     def _GeogPrimeMeridianLongGeoKey(value):
         if np.isscalar(value):
-            return {"pm" : float(value)}
-
+            return {"pm": float(value)}
 
     @staticmethod
     def _GeogSemiMajorAxisGeoKey(value):
         if np.isscalar(value):
-            return {"a" : float(value)}
-
+            return {"a": float(value)}
 
     @staticmethod
     def _ProjectionGeoKey(value):
@@ -251,21 +245,19 @@ class GeoKeysParser(object):
 
             return dict(proj="utm", zone=zone, south=south)
 
-
     @staticmethod
     def _ProjLinearUnitsGeoKey(value):
         # More units could be supported here
         unit_name = {9001: "m"}[value]
-        return {"units" : unit_name}
-
+        return {"units": unit_name}
 
     @staticmethod
     def _GeogCitationGeoKey(value):
         update = {}
 
         # Parse ellipsoid. GRS and WGS is probably enough
-        gcs_re = {"GRS":    ("GRS[ ,_]{0,1}(19|)\d\d", "\d\d$"),
-                  "WGS":    ("WGS[ ,_]{0,1}(19|)\d\d", "\d\d$"),
+        gcs_re = {"GRS":    ("GRS[ ,_]{0,1}(19|)\\d\\d", "\\d\\d$"),
+                  "WGS":    ("WGS[ ,_]{0,1}(19|)\\d\\d", "\\d\\d$"),
                   "sphere": ("sphere", None)}
 
         for (name, (pattern, postfix_pattern)) in gcs_re.items():
@@ -283,7 +275,7 @@ class GeoKeysParser(object):
         return update
 
 
-def identify_projection(image: TiffImageFile) -> str:
+def identify_projection(*, image: TiffImageFile) -> str:
     geokeys = extract_geo_keys(image=image)
     return GeoKeysParser(geokeys).to_proj4()
 
@@ -293,7 +285,7 @@ def img_slice(img, start_i, stop_i, start_j, stop_j):
     m, n = img.size
     if start_i > 0:
         try:
-            next(islice(myiter, start_i*n, start_i*n))
+            next(islice(myiter, start_i * n, start_i * n))
         except StopIteration:
             pass
     for i in range(stop_i - start_i):
@@ -311,7 +303,6 @@ def img_slice(img, start_i, stop_i, start_j, stop_j):
                 pass
 
 
-
 def read_raster_file(*,
                      filepath: Path,
                      x0: Optional[float] = None,
@@ -321,8 +312,10 @@ def read_raster_file(*,
     logger = getLogger()
     logger.debug(f"Reading raster file {filepath}")
     assert filepath.exists()
-    if x0 and x1: assert x0 < x1
-    if y0 and y1: assert y0 < y1
+    if x0 and x1:
+        assert x0 < x1
+    if y0 and y1:
+        assert y0 < y1
 
     with Image.open(filepath) as image:
         # Determine image extents
@@ -344,8 +337,8 @@ def read_raster_file(*,
 
         # Determine image coordinates, assuming here that the tie point is associated with pixel center.
         # Otherwise, coordinates should be shiftet half pixel size in both directions
-        X0, X1 = xt - jt * dx, xt + (n -1 - jt) * dx
-        Y1, Y0 = yt + it * dy, yt - (m -1 - it) * dy
+        X0, X1 = xt - jt * dx, xt + (n - 1 - jt) * dx
+        Y1, Y0 = yt + it * dy, yt - (m - 1 - it) * dy
 
         if x0 is None: x0 = X0
         if x1 is None: x1 = X1
@@ -354,16 +347,15 @@ def read_raster_file(*,
 
         # Identify pixel coordinates of view window extended to align with pixels
         j0 = max(int(np.floor((x0 - X0) / dx)), 0)
-        j1 = min(int(np.ceil((x1 - X0) / dx)), m-1)
+        j1 = min(int(np.ceil((x1 - X0) / dx)), m - 1)
         i0 = max(int(np.floor((Y1 - y1) / dy)), 0)
-        i1 = min(int(np.ceil((Y1 - y0) / dy)), n-1)
+        i1 = min(int(np.ceil((Y1 - y0) / dy)), n - 1)
 
         if j1 <= 0 or i1 <= 0 or i0 >= n or j0 >= m:
             # Empty view window, raise an error since PIL does not
             raise ValueError("Selected view window is outside of image bounds")
 
-        d = image.crop(box=(j0, i0, j1+1, i1+1))
-
+        d = image.crop(box=(j0, i0, j1 + 1, i1 + 1))
 
     # Get the actual coordinates of returned view window
     x0d, x1d = X0 + j0 * dx, X0 + j1 * dx

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -46,6 +46,7 @@ namespace rasputin {
 using Point = std::array<double, 3>;
 using PointList = std::vector<Point>;
 using VectorList = PointList;
+using ScalarList = std::vector<double>;
 using Vector = Point;
 using Face = std::array<int, 3>;
 using FaceList = std::vector<Face>;
@@ -200,6 +201,16 @@ VectorList orient_tin(const PointList &pts, FaceList &faces) {
         // Store normalised normal vector
         result.push_back(Vector{n.at(0)/c, n.at(1)/c, n.at(2)/c});
     }
+    return result;
+}
+
+ScalarList compute_slopes(const VectorList &normals) {
+    ScalarList result;
+    result.reserve(normals.size());
+
+    for (const auto &n : normals)
+        result.push_back(std::atan2(pow(pow(n[0], 2) + pow(n[1], 2), 0.5), n[2]));
+
     return result;
 }
 

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -181,7 +181,7 @@ VectorList orient_tin(const PointList &pts, FaceList &faces) {
     VectorList result;
     result.reserve(faces.size());
     for (auto& face: faces) {
-        // Compute normal
+        // Compute ccw normal
         const auto p0 = pts[face[0]];
         const auto p1 = pts[face[1]];
         const auto p2 = pts[face[2]];
@@ -190,15 +190,13 @@ VectorList orient_tin(const PointList &pts, FaceList &faces) {
         const arma::vec::fixed<3> n = arma::cross(v0, v1);
         double c = arma::norm(n);
 
-        // Reverse orientation if triangle is negatively oriented relative to xy plane
-        if (n[2] < 0.0)
-        {
+        // Reverse triangle orientation if it is negatively oriented relative to xy plane
+        if (n[2] < 0.0) {
           c *= -1.0;
           std::reverse(face.begin(), face.end());
-
         }
 
-        // Store normalised normal vector
+        // Store normalised and correctly oriented normal vector
         result.push_back(Vector{n.at(0)/c, n.at(1)/c, n.at(2)/c});
     }
     return result;

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -176,6 +176,33 @@ std::vector<std::vector<int>> compute_shadows(const PointList &pts,
     return result;
 }
 
+VectorList orient_tin(const PointList &pts, FaceList &faces) {
+    VectorList result;
+    result.reserve(faces.size());
+    for (auto& face: faces) {
+        // Compute normal
+        const auto p0 = pts[face[0]];
+        const auto p1 = pts[face[1]];
+        const auto p2 = pts[face[2]];
+        const arma::vec::fixed<3> v0 = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
+        const arma::vec::fixed<3> v1 = {p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]};
+        const arma::vec::fixed<3> n = arma::cross(v0, v1);
+        double c = arma::norm(n);
+
+        // Reverse orientation if triangle is negatively oriented relative to xy plane
+        if (n[2] < 0.0)
+        {
+          c *= -1.0;
+          std::reverse(face.begin(), face.end());
+
+        }
+
+        // Store normalised normal vector
+        result.push_back(Vector{n.at(0)/c, n.at(1)/c, n.at(2)/c});
+    }
+    return result;
+}
+
 VectorList surface_normals(const PointList &pts, const FaceList &faces) {
     VectorList result;
     result.reserve(faces.size());

--- a/src/rasputin/writer.py
+++ b/src/rasputin/writer.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union, Dict, Any
 from pathlib import Path
 import numpy as np
 from meshio import XdmfTimeSeriesWriter, write_points_cells
@@ -19,3 +19,68 @@ def write_mesh(*,
         writer.write_points_cells(pts, cells)
         for time, shade in shades:
             writer.write_data(time, cell_data={"triangle": {"shade": shade}})
+
+
+class Writer(object):
+    def __init__(self, *, filepath: Path):
+        self._filepath = filepath
+        self._point_data = dict()
+        self._cell_data = dict()
+        self._xdmfwriter = None
+
+    def __enter__(self):
+        self._xdmfwriter = XdmfTimeSeriesWriter(str(self._filepath))
+        return self
+
+    def __exit__(self, *args):
+        self._xdmfwriter = None
+
+    @property
+    def xdmfwriter(self):
+        if self._xdmfwriter is not None:
+            return self._xdmfwriter
+        else:
+            raise FileError("No file open!")
+
+    def set_tin(self, pts, faces):
+        self._pts = pts
+        self._faces = faces
+
+    def add_point_data(self, data, name):
+        self._point_data[name] = np.asarray(data)
+
+    def add_cell_data(self, data, name):
+        self._cell_data[name] = np.asarray(data)
+
+    def write_tin(self):
+        self.xdmfwriter.write_points_self(self._pts, self._faces)
+
+    def write_all(self, t: float = 0.0):
+        if not self.xdmfwriter.has_mesh:
+            self.write_tin()
+        self.xdmfwriter.write_data(t,
+                                   cell_data={"triangle": self._cell_data},
+                                   point_data=self._point_data)
+
+
+def write(*,
+          filepath: Path,
+          pts: triangulate_dem.PointVector,
+          faces: triangulate_dem.FaceVector,
+          t: float = 0.0,
+          fields: Dict["str", Any] = {}):
+    """
+    Convenience function for writing to file.
+    """
+    with Writer(filepath=filepath) as w:
+        w.set_tin(pts, faces)
+        for name, data in fields.items():
+            # Try to determine if field has point or cell data
+            # by counting number of values.
+            # Can fail for very small meshes
+            if len(data) == len(faces):
+                w.add_cell_data(data, name)
+            else:
+                w.add_point_data(data, name)
+
+        w.write_all(t=t)

--- a/src/rasputin/writer.py
+++ b/src/rasputin/writer.py
@@ -43,8 +43,8 @@ class Writer(object):
             raise FileError("No file open!")
 
     def set_tin(self, pts, faces):
-        self._pts = pts
-        self._faces = faces
+        self._pts = np.asarray(pts)
+        self._faces = np.asarray(faces)
 
     def add_point_data(self, data, name):
         self._point_data[name] = np.asarray(data)
@@ -53,7 +53,8 @@ class Writer(object):
         self._cell_data[name] = np.asarray(data)
 
     def write_tin(self):
-        self.xdmfwriter.write_points_self(self._pts, self._faces)
+        self.xdmfwriter.write_points_cells(self._pts,
+                                           {"triangle": self._faces})
 
     def write_all(self, t: float = 0.0):
         if not self.xdmfwriter.has_mesh:


### PR DESCRIPTION
This pull request includes some improvements to reading from GeoTIFF files:

- The window extracted from the GeoTIFF file is now specified in physical coordinates instead of pixel coordinates. Also, the coordinates are now for the lower left corner (x0, y0) and the upper right corner (x1,y1) (was upper left and and lower right in pixel coordinates).

- Data is extracted from the view window using `PIL.Image.crop` as in issue #5. It is not necessary to copy into a `numpy.ndarray`.

- The coordinates vector is now filled using a c++ function, avoiding a slow Python for-loop.

- Expanded `reader.extract_geo_keys` to cover most relevant keys in the GeoTIFF standard. 

- Basic functionality for identifying coordinate system from GeoKeys.

- Python buffer protocol for c++ types to avoid excessive copying.


Some other changes are also included:

- New c++ function `triangulate_dem.orient_tin` that computes and returns unit facet normals and fixes triangle orientations. This seems to fix shadow computations in some cases.

- New c++ function `triangulate_dem.compute_slope` for computing slope as in issue #6.

- A more convenient Python function `writer.write` for writing to file.