### PR TITLE
Change storage format from numpy to h5

### DIFF
--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -1,8 +1,8 @@
 from typing import Tuple, Dict, Any
 import numpy as np
 from datetime import datetime
+from h5py import File
 from pathlib import Path
-from json import loads, dumps
 from rasputin.triangulate_dem import PointVector, FaceVector
 
 
@@ -12,32 +12,37 @@ class TinRepository:
         self.path = path
 
     def read(self, *, uid: str) -> Tuple[PointVector, FaceVector]:
-        data = np.load(self.path / f"{uid}.npz")
-        pts = data["points"]
-        faces = data["faces"]
+        filename = self.path / f"{uid}.h5"
+        if not filename.exists():
+            raise FileNotFoundError(f"File {filename.absolute()} not found.")
+        with File(filename, "r") as archive:
+            pts = archive["tin"]["points"][:]
+            faces = archive["tin"]["faces"][:]
         return PointVector(pts.tolist()), FaceVector(faces.tolist())
 
     @property
     def content(self) -> Dict[str, Dict[str, Any]]:
-        files = self.path.glob("*.npz")
+        files = self.path.glob("*.h5")
         meta_info = dict()
         for f in files:
-            with f.with_suffix(".meta").open("r") as meta:
-                meta_info[f.stem] = loads(meta.read())
+            with File(f, "r") as archive:
+                meta_info[f.stem] = dict(timestamp=archive.attrs["timestamp"],
+                                         projection=archive["tin"]["points"].attrs["projection"],
+                                         num_points=archive["tin"]["points"].shape[0],
+                                         num_faces=archive["tin"]["faces"].shape[0])
         return meta_info
 
     def save(self, *, uid: str, points: PointVector, faces: FaceVector):
-        if (self.path / f"{uid}.npz").exists():
-            raise RuntimeError(f"Archive already has a data set with uid {uid}.")
-        if (self.path / f"{uid}.meta").exists():
-            raise RuntimeError(f"Archive already has a data set with uid {uid}.")
-        np.savez(self.path / f"{uid}.npz", points=points, faces=faces)
-        with (self.path / f"{uid}.meta").open("w") as meta:
-            meta.write(dumps(dict(num_points=len(points),
-                                  num_faces=len(faces),
-                                  timestamp=datetime.utcnow().timestamp())))
+        filename = self.path / f"{uid}.h5"
+        if filename.exists():
+            raise FileExistsError(f"Archive already has a data set with uid {uid}.")
+        with File(filename, "w") as archive:
+            grp = archive.create_group("tin")
+            obj = grp.create_dataset(name="points", data=np.asarray(points), dtype="d")
+            obj.attrs["projection"] = "NotSet"
+            grp.create_dataset(name="faces", data=np.asarray(faces), dtype="i")
+            archive.attrs["timestamp"] = datetime.utcnow().timestamp()
 
     def delete(self, uid: str) -> None:
         if uid in self.content:
-            (self.path / f"{uid}.npz").unlink()
-            (self.path / f"{uid}.meta").unlink()
+            (self.path / f"{uid}.h5").unlink()

--- a/tests/test_tin_repository.py
+++ b/tests/test_tin_repository.py
@@ -21,6 +21,8 @@ def test_store_tin(tin):
         assert uid in tr.content
         assert tr.content[uid]["num_points"] == len(pts)
         assert tr.content[uid]["num_faces"] == len(faces)
+        assert "timestamp" in tr.content[uid]
+        assert "projection" in tr.content[uid]
 
 
 def test_store_and_load_tin(tin):
@@ -43,6 +45,5 @@ def test_store_and_delete_tin(tin):
         tr.save(points=pts, faces=faces, uid=uid)
         tr.delete(uid=uid)
         assert uid not in tr.content
-        assert not (archive / f"{uid}.npz").exists()
-        assert not (archive / f"{uid}.meta").exists()
+        assert not (archive / f"{uid}.h5").exists()
 


### PR DESCRIPTION
This PR changes from numpy's compressed storage format + metadata in a separate file to hdf5 with metadata included. Tests are changed accordingly and run.