### PR TITLE
Land types

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,13 @@ Congratulations! You just triangulated a small mountain.
 High quality DTM data for Norway can be downloaded from free [here](https://hoydedata.no/LaserInnsyn/).
 Choose "Nedlasting" from the left hand side of the map, and choose "Landsdekkende", check "UTM-sone 33"
 and finally click DTM10. Download and unpack in, for instance, `$HOME/rasputin_data/dem_archive`, and
-`export RASPUTIN_DATA=$HOME/rasputin_data`.
+`export RASPUTIN_DATA_DIR=$HOME/rasputin_data`.
+
+It is possible to include land cover types in your triangulation, through the 
+[GlobCover dataset](http://due.esrin.esa.int/page_globcover.php) from ESA. It is a raster based 
+300m (approx) resolution data set that contains 23 different land cover types. 
+Download the data set and unpack it in `$RASPUTIN_DATA_DIR/globcov` to access the land types using
+the `rasputin.globcov_repository.GlobCovRepository` class.
 
 ## Acknowledges
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To test the installation run this for example in ipython:
 ```
 from rasputin import triangulate_dem
 
-vs = triangulate_dem.PointVector([(1,0,0), (0,1,0), (0,0,0), (0.25,0.25,1)])
+vs = triangulate_dem.point3_vector([(1,0,0), (0,1,0), (0,0,0), (0.25,0.25,1)])
 points, faces = triangulate_dem.lindstrom_turk_by_ratio(vs, 2.0)
 for f in faces:
    print(f)
@@ -96,7 +96,7 @@ Congratulations! You just triangulated a small mountain.
 
 High quality DTM data for Norway can be downloaded from free [here](https://hoydedata.no/LaserInnsyn/).
 Choose "Nedlasting" from the left hand side of the map, and choose "Landsdekkende", check "UTM-sone 33"
-and finally click DTM10. Download and unpack in, for instance, `$HOME/rasputin_data`, and
+and finally click DTM10. Download and unpack in, for instance, `$HOME/rasputin_data/dem_archive`, and
 `export RASPUTIN_DATA=$HOME/rasputin_data`.
 
 ## Acknowledges

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -70,7 +70,7 @@ def store_tin():
                                                                  input_coordinate_system=input_coordinate_system,
                                                                  target_coordinate_system=target_coordinate_system)
     points, faces = lindstrom_turk_by_ratio(raster_coords, res.ratio)
-    tr.save(uid=res.uid, points=points, faces=faces)
+    tr.save(uid=res.uid, points=points, faces=faces, projection=target_coordinate_system)
     meta = tr.content[res.uid]
     print(f"Successfully added uid='{res.uid}' to the tin archive {tin_archive.absolute()}, with meta info:")
     pprint.PrettyPrinter(indent=4).pprint(meta)

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -81,6 +81,7 @@ PYBIND11_MODULE(triangulate_dem, m) {
         .def("compute_slopes", &rasputin::compute_slopes,"Compute slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
         .def("compute_aspects", &rasputin::compute_aspects, "Compute aspects for the all the vectors in list.")
         .def("cell_centers", &rasputin::cell_centers, "Compute cell centers for triangulation.")
+        .def("consolidate", &rasputin::consolidate, "Make a stand alone consolidated tin.")
         .def("extract_avalanche_expositions", &rasputin::extract_avalanche_expositions, "Extract avalanche exposed cells.")
         .def("coordinates_to_indices", &rasputin::coordinates_to_indices, "Transform from coordinate space to index space.")
         .def("extract_uint8_buffer_values", &rasputin::extract_buffer_values<std::uint8_t>, "Extract raster data for given indices.")

--- a/src/rasputin/calculate.py
+++ b/src/rasputin/calculate.py
@@ -4,8 +4,8 @@ from rasputin import triangulate_dem
 
 
 def compute_shade(*,
-                  pts: triangulate_dem.PointVector,
-                  faces: triangulate_dem.FaceVector,
+                  pts: triangulate_dem.point3_vector,
+                  faces: triangulate_dem.face_vector,
                   sun_ray: List[float]) -> np.ndarray:
     assert len(sun_ray) == 3
     shades = triangulate_dem.compute_shadow(pts, faces, sun_ray)

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -40,8 +40,8 @@ THREE.MeshPhysicalMaterial( {
 class Geometry:
 
     def __init__(self, *,
-                 points: td.PointVector,
-                 faces: td.FaceVector,
+                 points: td.point3_vector,
+                 faces: td.face_vector,
                  base_color: Tuple[float, float, float],
                  material: str):
         self.points = points
@@ -55,13 +55,13 @@ class Geometry:
         self._material = material
 
     @property
-    def point_normals(self) -> td.PointVector:
+    def point_normals(self) -> td.point3_vector:
         if self._point_normals is None:
             self._point_normals = td.point_normals(self.points, self.faces)
         return self._point_normals
 
     @property
-    def surface_normals(self) -> td.PointVector:
+    def surface_normals(self) -> td.point3_vector:
         if self._surface_normals is None:
             self._surface_normals = td.surface_normals(self.points, self.faces)
         return self._surface_normals

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -1,0 +1,75 @@
+import numpy as np
+from pyproj import Proj
+from pathlib import Path
+from enum import Enum
+
+
+class GeoPoints:
+
+    def __init__(self, *, xy: np.ndarray, projection: Proj) -> None:
+        self.xy = xy
+        self.projection = projection
+
+
+class LandCoverType(Enum):
+    crop_type_1 = 11
+    crop_type_2 = 14
+    crop_type_3 = 20
+    crop_type_4 = 30
+    forest_type_1 = 40
+    forest_type_2 = 50
+    forest_type_3 = 60
+    forest_type_4 = 70
+    forest_type_5 = 90
+    forest_type_6 = 100
+    shrub_type_1 = 110
+    shrub_type_2 = 120
+    shrub_type_3 = 130
+    vegetation_type_1 = 140
+    vegetation_type_2 = 150
+    flood_type_1 = 160
+    flood_type_2 = 170
+    flood_type_3 = 180
+    artificial = 190
+    bare = 200
+    water = 210
+    snow_and_ice = 220
+    no_data = 230
+
+    @staticmethod
+    def describe(*, type="LandCoverType") -> str:
+        description = {
+            LandCoverType.crop_type_1: "Post-flooding or irrigated croplands (or aquatic)",
+            LandCoverType.crop_type_2: "Rainfed croplands",
+            LandCoverType.crop_type_3: "Mosaic cropland (50-70%) / vegetation (grassland/shrubland/forest) (20-50%)",
+            LandCoverType.crop_type_4: "Mosaic vegetation (grassland/shrubland/forest) (50-70%) / cropland (20-50%)",
+            LandCoverType.forest_type_1: "Closed to open (>15%) broadleaved evergreen or semi-deciduous forest (>5m)",
+            LandCoverType.forest_type_2: "Closed (>40%) broadleaved deciduous forest (>5m)",
+            LandCoverType.forest_type_3: "Open (15-40%) broadleaved deciduous forest/woodland (>5m)",
+            LandCoverType.forest_type_4: "Closed (>40%) needleleaved evergreen forest (>5m)",
+            LandCoverType.forest_type_5: "Open (15-40%) needleleaved deciduous or evergreen forest (>5m)",
+            LandCoverType.forest_type_6: "Closed to open (>15%) mixed broadleaved and needleleaved forest (>5m)",
+            LandCoverType.shrub_type_1: "Mosaic forest or shrubland (50-70%) / grassland (20-50%)",
+            LandCoverType.shrub_type_2: "Mosaic grassland (50-70%) / forest or shrubland (20-50%)",
+            LandCoverType.shrub_type_3: "Closed to open (>15%) (broadleaved or needleleaved, evergreen or deciduous) shrubland (<5m)",
+            LandCoverType.vegetation_type_1: "Closed to open (>15%) herbaceous vegetation (grassland, savannas or lichens/mosses)",
+            LandCoverType.vegetation_type_2: "Sparse (<15%) vegetation",
+            LandCoverType.flood_type_1: "Closed to open (>15%) broadleaved forest regularly flooded (semi-permanently or temporarily) - Fresh or brackish water",
+            LandCoverType.flood_type_2: "Closed (>40%) broadleaved forest or shrubland permanently flooded - Saline or brackish water",
+            LandCoverType.flood_type_3: "Closed to open (>15%) grassland or woody vegetation on regularly flooded or waterlogged soil - Fresh, brackish or saline water",
+            LandCoverType.artificial: "Artificial surfaces and associated areas (Urban areas >50%)",
+            LandCoverType.bare: "Bare areas",
+            LandCoverType.water: "Water bodies",
+            LandCoverType.snow_and_ice: "Permanent snow and ice",
+            LandCoverType.no_data: "No data (burnt areas, clouds,…)"}
+        return description[type]
+
+
+class GlobCovRepository:
+
+    def __init__(self, *, path: Path) -> None:
+        self.path = path
+        assert self.path.is_dir()
+
+    def read(self, *, land_type: LandCoverType, geo_points: GeoPoints) -> np.ndarray:
+        pass

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import List, Optional, Tuple
 from pathlib import Path
 from enum import Enum
 import numpy as np
@@ -43,7 +43,7 @@ class LandCoverType(Enum):
     no_data = 230
 
     @staticmethod
-    def describe(*, type="LandCoverType") -> str:
+    def describe(*, land_cover_type="LandCoverType") -> str:
         description = {
             LandCoverType.crop_type_1: "Post-flooding or irrigated croplands (or aquatic)",
             LandCoverType.crop_type_2: "Rainfed croplands",
@@ -68,7 +68,37 @@ class LandCoverType(Enum):
             LandCoverType.water: "Water bodies",
             LandCoverType.snow_and_ice: "Permanent snow and ice",
             LandCoverType.no_data: "No data (burnt areas, clouds,…)"}
-        return description[type]
+        return description[land_cover_type]
+
+    @staticmethod
+    def color(*, land_cover_type: "LandCoverType") -> Tuple[int, int, int]:
+        """Default colors for types in dataset."""
+        colors = {
+            LandCoverType.crop_type_1: (170, 240, 240),
+            LandCoverType.crop_type_2: (255, 255, 100),
+            LandCoverType.crop_type_3: (220, 240, 100),
+            LandCoverType.crop_type_4: (205, 205, 102),
+            LandCoverType.forest_type_1: (0, 100, 0),
+            LandCoverType.forest_type_2: (0, 160, 0),
+            LandCoverType.forest_type_3: (170, 200, 0),
+            LandCoverType.forest_type_4: (0, 60, 0),
+            LandCoverType.forest_type_5: (40, 100, 0),
+            LandCoverType.forest_type_6: (120, 130, 0),
+            LandCoverType.shrub_type_1: (140, 160, 0),
+            LandCoverType.shrub_type_2: (190, 150, 0),
+            LandCoverType.shrub_type_3: (150, 100, 0),
+            LandCoverType.vegetation_type_1: (255, 180, 50),
+            LandCoverType.vegetation_type_2: (255, 235, 175),
+            LandCoverType.flood_type_1: (0, 120, 90),
+            LandCoverType.flood_type_2: (0, 150, 120),
+            LandCoverType.flood_type_3: (0, 220, 130),
+            LandCoverType.artificial: (195, 20, 0),
+            LandCoverType.bare: (255, 245, 215),
+            LandCoverType.water: (0, 70, 200),
+            LandCoverType.snow_and_ice: (255, 255, 255),
+            LandCoverType.no_data: (0, 0, 0)
+        }
+        return colors[land_cover_type]
 
 
 class GlobCovRepository:

--- a/src/rasputin/mesh_colouring.py
+++ b/src/rasputin/mesh_colouring.py
@@ -6,7 +6,7 @@ from rasputin import triangulate_dem
 from rasputin.avalanche import varsom_angles
 
 
-def color_field_by_height(*, points: triangulate_dem.PointVector) -> np.ndarray:
+def color_field_by_height(*, points: triangulate_dem.point3_vector) -> np.ndarray:
     vertex_heights = np.asarray(points)[:, 2].copy()
     factor = 2
     vertex_heights -= min(vertex_heights)
@@ -20,7 +20,7 @@ def color_field_by_height(*, points: triangulate_dem.PointVector) -> np.ndarray:
 
 
 def add_slope_colors(*,
-                     normals: triangulate_dem.PointVector,
+                     normals: triangulate_dem.point3_vector,
                      colors: np.ndarray) -> np.ndarray:
     slopes = np.asanyarray(triangulate_dem.compute_slopes(normals))
     colors[slopes >= 55/180*np.pi] = [0.2, 0.2, 0.2]
@@ -28,7 +28,7 @@ def add_slope_colors(*,
 
 
 def color_field_by_slope(*,
-                         normals: triangulate_dem.PointVector) -> np.ndarray:
+                         normals: triangulate_dem.point3_vector) -> np.ndarray:
     slopes = np.asanyarray(triangulate_dem.compute_slopes(normals))
     colors = np.empty((len(slopes), 3))
     colors[slopes < 5.0e-2] = [0, 0, 1]
@@ -38,9 +38,9 @@ def color_field_by_slope(*,
 
 
 def color_field_by_avalanche_danger(*,
-                                    normals: triangulate_dem.PointVector,
-                                    points: triangulate_dem.PointVector,
-                                    faces: triangulate_dem.FaceVector,
+                                    normals: triangulate_dem.point3_vector,
+                                    points: triangulate_dem.point3_vector,
+                                    faces: triangulate_dem.face_vector,
                                     avalanche_problems: list,
                                     colors: Optional[np.ndarray]) -> np.ndarray:
     aspects = np.asarray(triangulate_dem.compute_aspects(normals))
@@ -85,7 +85,7 @@ def color_field_by_avalanche_danger(*,
     return colors
 
 
-def color_field_by_aspect(*, normals: triangulate_dem.PointVector)->np.ndarray:
+def color_field_by_aspect(*, normals: triangulate_dem.point3_vector)->np.ndarray:
 
     palette = sns.color_palette("pastel", n_colors=len(varsom_angles))
     aspects = np.asanyarray(triangulate_dem.compute_aspects(normals))

--- a/src/rasputin/mesh_utils.py
+++ b/src/rasputin/mesh_utils.py
@@ -3,8 +3,8 @@ from rasputin import triangulate_dem as td
 
 def face_field_to_vertex_values(*,
                                 face_field: np.ndarray,
-                                faces: td.FaceVector,
-                                points: td.PointVector) -> np.ndarray:
+                                faces: td.face_vector,
+                                points: td.point3_vector) -> np.ndarray:
     """
 
     :param field: scalar field over faces
@@ -21,8 +21,8 @@ def face_field_to_vertex_values(*,
 
 def vertex_field_to_vertex_values(*,
                                   vertex_field: np.ndarray,
-                                  faces: td.FaceVector,
-                                  points: td.PointVector) -> np.ndarray:
+                                  faces: td.face_vector,
+                                  points: td.point3_vector) -> np.ndarray:
     """
 
     :param field: color (vector) field over points

--- a/src/rasputin/py2js.py
+++ b/src/rasputin/py2js.py
@@ -5,7 +5,7 @@ from rasputin import triangulate_dem as td
 
 def face_vector_to_lines(*,
                          name: str,
-                         face_vector: td.FaceVector)-> Generator[str, None, None]:
+                         face_vector: td.face_vector)-> Generator[str, None, None]:
     yield f'const {name} = ['
     for v in face_vector:
         yield f"    {', '.join([str(s) for s in v])},"
@@ -14,7 +14,7 @@ def face_vector_to_lines(*,
 
 def point_vector_to_lines(*,
                           name: Optional[str],
-                          point_vector: Union[np.ndarray, td.PointVector])-> Generator[str, None, None]:
+                          point_vector: Union[np.ndarray, td.point3_vector])-> Generator[str, None, None]:
     if name is not None:
         yield f'const {name} = new Float32Array( ['
     else:
@@ -29,8 +29,8 @@ def point_vector_to_lines(*,
 
 def face_and_point_vector_to_lines(*,
                                    name: Optional[str],
-                                   face_vector: td.FaceVector,
-                                   point_vector: td.PointVector) -> Generator[str, None, None]:
+                                   face_vector: td.face_vector,
+                                   point_vector: td.point3_vector) -> Generator[str, None, None]:
     if name is not None:
         yield f'const {name} = new Float32Array( ['
     else:

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -3,8 +3,6 @@ import numpy as np
 from datetime import datetime
 from h5py import File
 from pathlib import Path
-<<<<<<< HEAD
-from json import loads, dumps
 from rasputin.triangulate_dem import point3_vector, face_vector
 
 

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -3,7 +3,7 @@ import numpy as np
 from datetime import datetime
 from pathlib import Path
 from json import loads, dumps
-from rasputin.triangulate_dem import PointVector, FaceVector
+from rasputin.triangulate_dem import point3_vector, face_vector
 
 
 class TinRepository:
@@ -11,11 +11,11 @@ class TinRepository:
     def __init__(self, *, path: Path) -> None:
         self.path = path
 
-    def read(self, *, uid: str) -> Tuple[PointVector, FaceVector]:
+    def read(self, *, uid: str) -> Tuple[point3_vector, face_vector]:
         data = np.load(self.path / f"{uid}.npz")
         pts = data["points"]
         faces = data["faces"]
-        return PointVector(pts.tolist()), FaceVector(faces.tolist())
+        return point3_vector(pts.tolist()), face_vector(faces.tolist())
 
     @property
     def content(self) -> Dict[str, Dict[str, Any]]:
@@ -26,7 +26,7 @@ class TinRepository:
                 meta_info[f.stem] = loads(meta.read())
         return meta_info
 
-    def save(self, *, uid: str, points: PointVector, faces: FaceVector):
+    def save(self, *, uid: str, points: point3_vector, faces: face_vector):
         if (self.path / f"{uid}.npz").exists():
             raise RuntimeError(f"Archive already has a data set with uid {uid}.")
         if (self.path / f"{uid}.meta").exists():

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -1,9 +1,10 @@
-from typing import Tuple, Dict, Any
+from typing import Dict, Any
 import numpy as np
 from datetime import datetime
 from h5py import File
 from pathlib import Path
-from rasputin.triangulate_dem import point3_vector, face_vector
+from rasputin.triangulate_dem import point3_vector, face_vector, consolidate
+from rasputin.geometry import Geometry
 
 
 class TinRepository:
@@ -12,20 +13,36 @@ class TinRepository:
         self.path = path
 
     def info(self, *, uid: str) -> Dict[str, Any]:
+        info = dict(tins=dict())
         with File(self.path / f"{uid}.h5", "r") as archive:
-            return dict(timestamp=archive.attrs["timestamp"],
-                        projection=archive["tin"]["points"].attrs["projection"],
-                        num_points=archive["tin"]["points"].shape[0],
-                        num_faces=archive["tin"]["faces"].shape[0])
+            info["timestamp"] = archive.attrs["timestamp"]
+            for name in archive["tins"].keys():
+                grp = archive["tins"][name]
+                info["tins"][name] = dict(projection=grp["points"].attrs["projection"],
+                                          num_points=grp["points"].shape[0],
+                                          num_faces=grp["faces"].shape[0],
+                                          color=grp["faces"].attrs["color"])
+            return info
 
-    def read(self, *, uid: str) -> Tuple[point3_vector, face_vector]:
+    def read(self, *, uid: str) -> Dict[str, Geometry]:
         filename = self.path / f"{uid}.h5"
         if not filename.exists():
             raise FileNotFoundError(f"File {filename.absolute()} not found.")
+        geometries = dict()
         with File(filename, "r") as archive:
-            pts = archive["tin"]["points"][:]
-            faces = archive["tin"]["faces"][:]
-        return point3_vector(pts.tolist()), face_vector(faces.tolist())
+            root_group = archive["tins"]
+            for name in root_group.keys():
+                group = root_group[name]
+                pts = group["points"][:]
+                projection = group["points"].attrs["projection"]
+                faces = group["faces"][:]
+                color = group["faces"].attrs["color"]
+                geometries[name] = Geometry(points=point3_vector(pts.tolist()),
+                                            faces=face_vector(faces.tolist()),
+                                            projection=projection,
+                                            base_color=color,
+                                            material=None)
+        return geometries
 
     @property
     def content(self) -> Dict[str, Dict[str, Any]]:
@@ -35,17 +52,23 @@ class TinRepository:
             meta_info[f.stem] = self.info(uid=f.stem)
         return meta_info
 
-
-    def save(self, *, uid: str, points: point3_vector, faces: face_vector):
+    def save(self, *, uid: str, geometries: Dict[str, Geometry], consolidate_mesh: bool=False) -> None:
         filename = self.path / f"{uid}.h5"
         if filename.exists():
             raise FileExistsError(f"Archive already has a data set with uid {uid}.")
         with File(filename, "w") as archive:
-            grp = archive.create_group("tin")
-            obj = grp.create_dataset(name="points", data=np.asarray(points), dtype="d")
-            obj.attrs["projection"] = "NotSet"
-            grp.create_dataset(name="faces", data=np.asarray(faces), dtype="i")
             archive.attrs["timestamp"] = datetime.utcnow().timestamp()
+            root_grp = archive.create_group("tins")
+            for name, geom in geometries.items():
+                grp = root_grp.create_group(name)
+                if consolidate_mesh:
+                    points, faces = consolidate(geom.points, geom.faces)
+                else:
+                    points, faces = geom.points, geom.faces
+                h5_points = grp.create_dataset(name="points", data=np.asarray(points), dtype="d")
+                h5_points.attrs["projection"] = geom.projection
+                h5_faces = grp.create_dataset(name="faces", data=np.asarray(faces), dtype="i")
+                h5_faces.attrs["color"] = geom.base_color
 
     def delete(self, uid: str) -> None:
         if uid in self.content:

--- a/src/rasputin/web_visualize.py
+++ b/src/rasputin/web_visualize.py
@@ -26,7 +26,7 @@ def web_visualize():
 
     """
     if "RASPUTIN_DATA_DIR" in os.environ:
-        data_dir = Path(os.environ["RASPUTIN_DATA_DIR"])
+        data_dir = Path(os.environ["RASPUTIN_DATA_DIR"]) / "dem_archive"
     else:
         #  data_dir = Path(os.environ["HOME"]) /"projects" / "rasputin_data" / "dem_archive"
         data_dir = Path(".") / "dem_archive"

--- a/src/rasputin/wfs_repository.py
+++ b/src/rasputin/wfs_repository.py
@@ -1,0 +1,40 @@
+from typing import Optional, Dict, List
+from owslib.wfs import WebFeatureService
+from owslib.fes import PropertyIsLike
+from owslib.etree import etree
+
+
+class GeoPolygon:
+    pass
+
+
+class LandCoverType(Enum):
+    pass
+
+
+class InspireLandtypeRepository:
+
+    def __init__(self):
+        pass
+
+    @property
+    def land_cover_types(self, *, constraint: Optional[GeoPolygon] = None) -> List[LandCoverType]:
+        pass
+
+    def read(self, *, land_type: LandCoverType, constraint: GeoPolygon) -> List[GeoPolygon]:
+        return self.read_all(land_types=[land_type], constraint=constraint)[land_type]
+
+    def read_all(self, *, land_types: List[LandCoverType], constraint: GeoPolygon) -> Dict[LandCoverType, List[GeoPolygon]:
+        pass
+
+# Some test code using owslib. Have not yet figured out how to use the WebFeatureService to extract a subset of land surface types as
+# polygons. Below is a simple test summing up my understanding up to now. See also:
+# * https://www.linz.govt.nz/data/linz-data-service/guides-and-documentation/wfs-filtering-by-attribute-or-feature
+# * https://geopython.github.io/OWSLib/
+# * https://kartkatalog.geonorge.no/metadata/kartverket/inspire-landcovervector-wfs/c1f5f3de-ce2d-4104-bee3-2560c5a5a948
+
+def test()
+    wfs = WebFeatureService("https://wfs.geonorge.no/skwms1/wfs.inspire-lcv", version="2.0.0")
+    filter = PropertyIsLike(propertyname="lcv:LandCoverObservation", literal="21")
+    filterxml = etree.tostring(filter.toXML()).decode("utf-8")
+    response = wfs.getfeature(typename="lcv:LandCoverUnit", filter=filterxml)

--- a/src/rasputin/wfs_repository.py
+++ b/src/rasputin/wfs_repository.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, List
+from enum import Enum
 from owslib.wfs import WebFeatureService
 from owslib.fes import PropertyIsLike
 from owslib.etree import etree
@@ -17,7 +18,6 @@ class InspireLandtypeRepository:
     def __init__(self):
         pass
 
-    @property
     def land_cover_types(self, *, constraint: Optional[GeoPolygon] = None) -> List[LandCoverType]:
         pass
 
@@ -33,7 +33,7 @@ class InspireLandtypeRepository:
 # * https://geopython.github.io/OWSLib/
 # * https://kartkatalog.geonorge.no/metadata/kartverket/inspire-landcovervector-wfs/c1f5f3de-ce2d-4104-bee3-2560c5a5a948
 
-def test()
+def test():
     wfs = WebFeatureService("https://wfs.geonorge.no/skwms1/wfs.inspire-lcv", version="2.0.0")
     filter = PropertyIsLike(propertyname="lcv:LandCoverObservation", literal="21")
     filterxml = etree.tostring(filter.toXML()).decode("utf-8")

--- a/src/rasputin/wfs_repository.py
+++ b/src/rasputin/wfs_repository.py
@@ -24,7 +24,7 @@ class InspireLandtypeRepository:
     def read(self, *, land_type: LandCoverType, constraint: GeoPolygon) -> List[GeoPolygon]:
         return self.read_all(land_types=[land_type], constraint=constraint)[land_type]
 
-    def read_all(self, *, land_types: List[LandCoverType], constraint: GeoPolygon) -> Dict[LandCoverType, List[GeoPolygon]:
+    def read_all(self, *, land_types: List[LandCoverType], constraint: GeoPolygon) -> Dict[LandCoverType, List[GeoPolygon]]:
         pass
 
 # Some test code using owslib. Have not yet figured out how to use the WebFeatureService to extract a subset of land surface types as

--- a/src/rasputin/writer.py
+++ b/src/rasputin/writer.py
@@ -6,8 +6,8 @@ from rasputin import triangulate_dem
 
 
 def write_mesh(*,
-               pts: triangulate_dem.PointVector,
-               faces: triangulate_dem.FaceVector,
+               pts: triangulate_dem.point3_vector,
+               faces: triangulate_dem.face_vector,
                shades: List[Tuple[int, np.ndarray]],
                filepath: Path) -> None:
     """Write mesh to file...
@@ -74,8 +74,8 @@ class Writer(object):
 
 def write(*,
           filepath: Path,
-          pts: triangulate_dem.PointVector,
-          faces: triangulate_dem.FaceVector,
+          pts: triangulate_dem.point3_vector,
+          faces: triangulate_dem.face_vector,
           t: float = 0.0,
           fields: Dict["str", Any] = {}):
     """

--- a/tests/test_land_cover_repository.py
+++ b/tests/test_land_cover_repository.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import numpy as np
+from pyproj import Proj
+from rasputin import triangulate_dem as td
+from rasputin.globcov_repository import GlobCovRepository, GeoPoints, LandCoverType
+from rasputin.reader import RasterRepository
+import os
+
+
+def test_coordinates_to_indices():
+    dx = dy = 10  # Raster resolution
+    M, N = 100, 100  # Number of rows and columns in raster
+    x0 = 0  # Model x tie point
+    y1 = 100  # Model y tie point
+    points = td.point2_vector([[5.0, 95.0], [15.0, 85.0]])
+    res = np.asarray(td.coordinates_to_indices(x0, y1, dx, dy, M, N, points))
+    assert res[0].tolist() == [0, 0]
+    assert res[1].tolist() == [1, 1]
+
+
+def test_extract_land_types():
+    path = Path('/Users/skavhaug/projects/rasputin_data/globcov')
+    xy = np.array([[8, 60], [8.1, 61]], dtype='d')
+    proj = Proj(init="EPSG:4326")
+    geo_points = GeoPoints(xy=xy, projection=proj)
+    gcr = GlobCovRepository(path=path)
+    gcr.read(land_type=LandCoverType.crop_type_2, geo_points=geo_points)
+
+def test_construct_triangulation_with_land_types():
+    assert "RASPUTIN_DATA_DIR" in os.environ
+    data_dir = Path(os.environ["RASPUTIN_DATA_DIR"])
+    lt_repo = GlobCovRepository(path=data_dir/ "globcov")
+    dem_repo = RasterRepository(directory=data_dir / "dem_archive")
+    x0 = 8.54758671814368
+    y0 = 60.898468
+    input_coordinate_system = Proj(init="EPSG:4326")
+    target_coordinate_system = Proj(init="EPSG:32633")
+    raster_coords = dem_repo.read(x=x0,
+                                  y=y0,
+                                  dx=600,
+                                  dy=600,
+                                  input_coordinate_system=input_coordinate_system.definition_string(),
+                                  target_coordinate_system=target_coordinate_system.definition_string())
+    points, faces = td.lindstrom_turk_by_ratio(raster_coords, 0.1)
+    centers = np.asarray(td.cell_centers(points, faces))[:, :2]
+    land_types = lt_repo.read_types(land_types=None,
+                                    geo_points=GeoPoints(xy=centers,
+                                                         projection=target_coordinate_system))
+    assert len(land_types) == len(faces)


### PR DESCRIPTION
This PR adds land types from GlobCover 300x300m raster data to the triangulation. The criterion used is center point location of each cell. The tin is then partitioned by the land types and stored in the tin repository.