### PR TITLE
Constrained triangulation

### DIFF
--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -4,8 +4,9 @@ from pathlib import Path
 import numpy as np
 import pprint
 import pyproj
+from shapely.geometry import Polygon
 import argparse
-from rasputin.reader import RasterRepository
+from rasputin.reader import RasterRepository, GeoPolygon
 from rasputin.tin_repository import TinRepository
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio, extract_lakes, cell_centers, face_vector
 from rasputin.geometry import Geometry, write_scene, lake_material, terrain_material
@@ -45,10 +46,12 @@ def store_tin():
         raise RuntimeError(f"{tin_archive} exists and is not a directory, giving up.")
 
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument("-lat", type=float, default=60.898468, help="Latitude of center coordinate")
-    arg_parser.add_argument("-lon", type=float, default=8.530918, help="Longitude of center coordinate")
-    arg_parser.add_argument("-dx", type=float, default=5000, help="Distance in meters")
-    arg_parser.add_argument("-dy", type=float, default=5000, help="Distance in meters")
+    #arg_parser.add_argument("-lat", type=float, default=60.898468, help="Latitude of center coordinate")
+    #arg_parser.add_argument("-lon", type=float, default=8.530918, help="Longitude of center coordinate")
+    arg_parser.add_argument("-x", nargs="+", type=float, help="x-coordinates of polygon", default=None)
+    arg_parser.add_argument("-y", nargs="+", type=float, help="y-coordinates of polygon", default=None)
+    #arg_parser.add_argument("-dx", type=float, default=5000, help="Distance in meters")
+    #arg_parser.add_argument("-dy", type=float, default=5000, help="Distance in meters")
     arg_parser.add_argument("-ratio", type=float, default=0.4, help="Mesh coarsening factor in [0, 1]")
     arg_parser.add_argument("-override", action="store_true", help="Replace existing archive entry")
     arg_parser.add_argument("-land-type-partition", action="store_true", help="Partition mesh my land type")
@@ -61,22 +64,32 @@ def store_tin():
             raise RuntimeError(f"Tin archive {tin_archive.absolute()} already contains uid {res.uid}.")
         else:
             tr.delete(res.uid)
-    # Define area of interest
-    x0 = res.lon
-    y0 = res.lat
-    dx = res.dx
-    dy = res.dy
 
+    # Determine region of interest
+    if not res.x or not res.y:
+        raise RuntimeError("A constraining polygon is needed")
+
+    # Define area of interest
+    x_coords = res.x
+    y_coords = res.y
+
+    # TODO: Fix!
     input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
     target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
 
-    raster_coords = RasterRepository(directory=dem_archive).read(x=x0,
-                                                                 y=y0,
-                                                                 dx=dx,
-                                                                 dy=dy,
-                                                                 input_coordinate_system=input_coordinate_system,
-                                                                 target_coordinate_system=target_coordinate_system)
-    points, faces = lindstrom_turk_by_ratio(raster_coords, res.ratio)
+    if 3 <= len(x_coords) == len(y_coords):
+        x_coords, y_coords = pyproj.transform(input_coordinate_system, target_coordinate_system, x_coords, y_coords)
+        polygon = Polygon((x, y) for (x, y) in zip(x_coords, y_coords))
+    else:
+        raise ValueError("x and y coordinates must have equal length greater or equal to 3")
+
+
+    geo_polygon = GeoPolygon(polygon=polygon, proj=target_coordinate_system)
+
+    raster_data_list, cpp_polygon = RasterRepository(directory=dem_archive).read(domain=geo_polygon)
+    points, faces = lindstrom_turk_by_ratio(raster_data_list,
+                                            cpp_polygon,
+                                            res.ratio)
     if not res.land_type_partition:
         tr.save(uid=res.uid, geometries={"terrain": Geometry(points=points,
                                                              faces=faces, projection=target_coordinate_system,

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -23,6 +23,7 @@ PYBIND11_MAKE_OPAQUE(rasputin::PointList);
 PYBIND11_MAKE_OPAQUE(rasputin::PointList2D);
 PYBIND11_MAKE_OPAQUE(rasputin::FaceList);
 PYBIND11_MAKE_OPAQUE(rasputin::ScalarList);
+PYBIND11_MAKE_OPAQUE(CGAL::MultiPolygon);
 
 template<typename T, std::size_t n>
 py::buffer_info vecarray_buffer(std::vector<std::array<T, n>> &v) {
@@ -74,6 +75,72 @@ py::buffer_info vector_buffer(std::vector<T> &v) {
     return py::buffer_info(&v[0], sizeof(T), py::format_descriptor<T>::format(), 1, { v.size() }, { sizeof(T) });
 }
 
+
+template<typename P0, typename P1>
+CGAL::MultiPolygon difference_polygons(const P0& polygon0, const P1& polygon1) {
+    CGAL::MultiPolygon difference_result;
+    CGAL::difference(polygon0, polygon1, std::back_inserter(difference_result));
+
+    return difference_result;
+}
+
+template<typename P0, typename P1>
+CGAL::MultiPolygon intersect_polygons(const P0& polygon0, const P1& polygon1) {
+    CGAL::MultiPolygon intersection_result;
+    CGAL::intersection(polygon0, polygon1, std::back_inserter(intersection_result));
+
+    return intersection_result;
+}
+
+template<typename P0, typename P1>
+CGAL::MultiPolygon join_polygons(const P0& polygon0, const P1& polygon1) {
+    CGAL::Polygon joined;
+    CGAL::MultiPolygon join_result;
+    if (CGAL::join(polygon0, polygon1, joined))
+        join_result.push_back(std::move(joined));
+    else {
+        join_result.push_back(CGAL::Polygon(polygon0));
+        join_result.push_back(CGAL::Polygon(polygon1));
+    }
+    return join_result;
+}
+
+
+CGAL::MultiPolygon join_multipolygons(const CGAL::MultiPolygon& polygon0, const CGAL::MultiPolygon& polygon1) {
+    CGAL::MultiPolygon join_result;
+    CGAL::join(polygon0.begin(), polygon0.end(), polygon1.begin(), polygon1.end(), std::back_inserter(join_result));
+
+    return join_result;
+}
+
+
+
+CGAL::SimplePolygon polygon_from_numpy(py::array_t<double>& buf) {
+        auto info = buf.request();
+        if (info.ndim < 1 or info.ndim > 2)
+            throw py::type_error("Can only convert one- and two-dimensional arrays.");
+
+        // Make sure total size can be preserved
+        auto size = info.shape[0];
+        if (info.ndim == 1 and size % 2)
+            throw py::type_error("Size of one-dimensional array must be divisible by 2.");
+
+        if (info.ndim == 2 and info.shape[1] != 2)
+            throw py::type_error("Second dimension does not have size equal to 2.");
+
+        if (info.ndim == 2)
+            size *= 2;
+
+        CGAL::SimplePolygon exterior;
+
+        // Copy values
+        double* p = static_cast<double*>(info.ptr);
+        double* end = p + size;
+
+        for (; p < end; p += 2)
+            exterior.push_back(CGAL::Point2(*p, *(p+1)));
+        return exterior;
+}
 
 template<typename FT>
 void bind_rasterdata(py::module &m, const std::string& pyname) {
@@ -154,6 +221,83 @@ PYBIND11_MODULE(triangulate_dem, m) {
       .def("from_numpy", &vecarray_from_numpy<int, 3>);
     py::bind_vector<rasputin::ScalarList>(m, "ScalarVector", py::buffer_protocol())
       .def_buffer(&vector_buffer<double>);
+
+    py::class_<CGAL::SimplePolygon, std::unique_ptr<CGAL::SimplePolygon>>(m, "SimplePolygon")
+        .def(py::init(&polygon_from_numpy))
+        .def("num_vertices", &CGAL::SimplePolygon::size)
+        .def("array", [] (const CGAL::SimplePolygon& self) {
+                py::array_t<double> result(self.size() * 2);
+                result.resize(py::array::ShapeContainer({static_cast<long int>(self.size()), 2}), true);
+                auto info = result.request();
+                double* data = static_cast<double*>(info.ptr);
+                for (auto v = self.vertices_begin(); v != self.vertices_end(); ++v) {
+                    data[0] = v->x();
+                    data[1] = v->y();
+                    data += 2;
+                }
+                return result;
+                }, py::return_value_policy::move)
+        .def("join", &join_polygons<CGAL::SimplePolygon, CGAL::SimplePolygon>)
+        .def("join", &join_polygons<CGAL::SimplePolygon, CGAL::Polygon>)
+        .def("difference", &difference_polygons<CGAL::SimplePolygon, CGAL::SimplePolygon>)
+        .def("difference", &difference_polygons<CGAL::SimplePolygon, CGAL::Polygon>)
+        .def("intersection", &intersect_polygons<CGAL::SimplePolygon, CGAL::SimplePolygon>)
+        .def("intersection", &intersect_polygons<CGAL::SimplePolygon, CGAL::Polygon>);
+
+    py::class_<CGAL::Polygon, std::unique_ptr<CGAL::Polygon>>(m, "Polygon")
+        .def(py::init([] (py::array_t<double>& buf) {
+            const CGAL::SimplePolygon exterior = polygon_from_numpy(buf);
+            return CGAL::Polygon(exterior);}))
+        .def("holes", [] (const CGAL::Polygon& self) {
+                    py::list result;
+                    for (auto h = self.holes_begin(); h != self.holes_end(); ++h)
+                        result.append(*h);
+                    return result;
+                    })
+        .def("exterior", [] (const CGAL::Polygon& self) {return self.outer_boundary();})
+        .def("join", &join_polygons<CGAL::Polygon, CGAL::SimplePolygon>)
+        .def("join", &join_polygons<CGAL::Polygon, CGAL::Polygon>)
+        .def("difference", &difference_polygons<CGAL::Polygon, CGAL::SimplePolygon>)
+        .def("difference", &difference_polygons<CGAL::Polygon, CGAL::Polygon>)
+        .def("intersection", &intersect_polygons<CGAL::Polygon, CGAL::SimplePolygon>)
+        .def("intersection", &intersect_polygons<CGAL::Polygon, CGAL::Polygon>);
+
+    py::class_<CGAL::MultiPolygon, std::unique_ptr<CGAL::MultiPolygon>>(m, "MultiPolygon")
+        .def(py::init(
+            [] (const CGAL::Polygon& polygon) {
+                CGAL::MultiPolygon self;
+                self.push_back(CGAL::Polygon(polygon));
+                return self;
+            }))
+        .def(py::init(
+            [] (const CGAL::SimplePolygon& polygon) {
+                CGAL::MultiPolygon self;
+                self.push_back(CGAL::Polygon(polygon));
+                return self;
+            }))
+        .def("num_parts", &CGAL::MultiPolygon::size)
+        .def("parts",
+            [] (const CGAL::MultiPolygon& self) {
+                py::list result;
+                for (auto p = self.begin(); p != self.end(); ++p)
+                    result.append(*p);
+                return result;
+            })
+        .def("join",
+            [] (const CGAL::MultiPolygon a, CGAL::SimplePolygon b) {
+                return join_multipolygons(a, CGAL::MultiPolygon({static_cast<CGAL::Polygon>(b)}));
+            })
+        .def("join",
+            [] (const CGAL::MultiPolygon a, CGAL::Polygon b) {
+                return join_multipolygons(a, CGAL::MultiPolygon({b}));
+            })
+        .def("join",
+            [] (const CGAL::MultiPolygon a, CGAL::MultiPolygon b) {
+                return join_multipolygons(a, b);
+            })
+        .def("__getitem__", [] (const CGAL::MultiPolygon& self, int idx) {
+                    return self.at(idx);
+                    }, py::return_value_policy::reference_internal);
 
     bind_rasterdata<float>(m, "RasterData_float");
     bind_rasterdata<double>(m, "RasterData_double");

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -109,6 +109,14 @@ void bind_rasterdata(py::module &m, const std::string& pyname) {
     .def("get_interpolated_value_at_point", &rasputin::RasterData<FT>::get_interpolated_value_at_point);
 
     m.def("lindstrom_turk_by_size",
+          [] (const rasputin::RasterData<FT>& raster_data, const rasputin::PointList2D& boundary_vertices, size_t result_mesh_size) {
+              return rasputin::tin_from_raster(raster_data, boundary_vertices,
+                                        SMS::Count_stop_predicate<CGAL::Mesh>(result_mesh_size),
+                                        SMS::LindstromTurk_placement<CGAL::Mesh>(),
+                                        SMS::LindstromTurk_cost<CGAL::Mesh>());
+          },
+          "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the size threshold.")
+     .def("lindstrom_turk_by_size",
           [] (const rasputin::RasterData<FT>& raster_data, size_t result_mesh_size) {
               return rasputin::tin_from_raster(raster_data,
                                         SMS::Count_stop_predicate<CGAL::Mesh>(result_mesh_size),
@@ -117,29 +125,21 @@ void bind_rasterdata(py::module &m, const std::string& pyname) {
           },
           "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the size threshold.")
         .def("lindstrom_turk_by_ratio",
+             [] (const rasputin::RasterData<FT>& raster_data, const rasputin::PointList2D& boundary_vertices, double ratio) {
+                 return rasputin::tin_from_raster(raster_data, boundary_vertices,
+                                           SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
+                                           SMS::LindstromTurk_placement<CGAL::Mesh>(),
+                                           SMS::LindstromTurk_cost<CGAL::Mesh>());
+             },
+            "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.")
+        .def("lindstrom_turk_by_ratio",
              [] (const rasputin::RasterData<FT>& raster_data, double ratio) {
                  return rasputin::tin_from_raster(raster_data,
                                            SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
                                            SMS::LindstromTurk_placement<CGAL::Mesh>(),
                                            SMS::LindstromTurk_cost<CGAL::Mesh>());
              },
-            "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.")
-    .def("tin_from_raster",
-            [] (const rasputin::RasterData<FT>& raster, rasputin::PointList2D& boundary_vertices, const double ratio) {
-            return rasputin::tin_from_raster(raster, boundary_vertices,
-                                             SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
-                                             SMS::LindstromTurk_placement<CGAL::Mesh>(),
-                                             SMS::LindstromTurk_cost<CGAL::Mesh>());
-        }
-    )
-    .def("tin_from_raster",
-            [] (const rasputin::RasterData<FT>& raster, const double ratio) {
-            return rasputin::tin_from_raster(raster,
-                                             SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
-                                             SMS::LindstromTurk_placement<CGAL::Mesh>(),
-                                             SMS::LindstromTurk_cost<CGAL::Mesh>());
-            }
-    );
+            "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.");
 }
 
 PYBIND11_MODULE(triangulate_dem, m) {

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -39,6 +39,92 @@ py::buffer_info vector_buffer(std::vector<T> &v) {
     return py::buffer_info(&v[0], sizeof(T), py::format_descriptor<T>::format(), 1, { v.size() }, { sizeof(T) });
 }
 
+rasputin::PointList rasterdata_to_pointvector(py::array_t<double> array, double x0, double y0, double x1, double y1) {
+                 auto buffer = array.request();
+                 int m = buffer.shape[0], n = buffer.shape[1];
+                 double* ptr = (double*) buffer.ptr;
+
+                 double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
+
+                 rasputin::PointList raster_coordinates;
+                 raster_coordinates.reserve(m*n);
+                 for (std::size_t i = 0; i < m; ++i)
+                     for (std::size_t j = 0; j < n; ++j)
+                         raster_coordinates.push_back(std::array<double, 3>{x0 + j*dx, y1 - i*dy, ptr[i*n + j]});
+                 return raster_coordinates;
+            }
+
+rasputin::PointList interpolate_onto_polygon(py::array_t<double> array, double x0, double y0, double x1, double y1, rasputin::PointList polygon) {
+    auto buffer = array.request();
+    int m = buffer.shape[0], n = buffer.shape[1];
+    double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
+    double* ptr = (double*) buffer.ptr;
+
+    auto get_index= [x0,y1,dx,dy](double x, double y) -> std::pair<int, int> {
+        int j = static_cast<int>((x-x0) /dx);
+        int i = static_cast<int>((y1-y) /dy);
+
+        return std::make_pair(i,j);
+    };
+
+    rasputin::PointList interpolated_points;
+    for (std::size_t vertex_number = 0; vertex_number < polygon.size(); ++vertex_number) {
+        rasputin::Point vertex = polygon[vertex_number];
+
+        rasputin::Point second_vertex = polygon[(vertex_number + 1) % polygon.size()];
+
+        // Sample with the same resolution along the polygon edges
+        double edge_len_x = second_vertex[0] - vertex[0];
+        double edge_len_y = second_vertex[1] - vertex[1];
+
+        double edge_len = pow(pow(edge_len_x, 2) + pow(edge_len_y, 2), 0.5);
+
+        // Not including next vertex
+        std::size_t num_samples = static_cast<int>(std::max<double>(std::fabs(edge_len_x/dx), std::fabs(edge_len_y/dy)));
+        double edge_dx = edge_len_x / num_samples;
+        double edge_dy = edge_len_y / num_samples;
+
+        for (std::size_t k=0; k < num_samples; ++k) {
+            double x = vertex[0] + k * edge_dx;
+            double y = vertex[1] + k * edge_dy;
+            auto indices = get_index(x, y);
+
+            int i = indices.first, j = indices.second;
+
+            // Bilinear interpolation
+            // h = h_i_j0 * (x_i1 - x)/dx
+            //   + h_i_j1 * (x - x_i0)/dx
+            //
+            //   = h_i0_j0 * (x_i1 -x)/dx * (yi1 - y)/dy
+            //   + h_i1_j0 * (x_i1 -x)/dx * (y - yi0)/dy
+            //   + ...
+            //   yi0 = y1 -i * dy
+            //   yi1 = y1 -(i+1) * dy
+            double x_j0 = x0 + (j+0) * dx;
+            double x_j1 = x0 + (j+1) * dx;
+            double y_i0 = y1 - (i+0) * dy;
+            double y_i1 = y1 - (i+1) * dy;
+            /* double h = ptr[(i + 0)*n + j+0] * ((j+1)*dx  +x0 - x)/dx * -(y1 - (i+1) * dy - y)/dy */
+            /*          + ptr[(i + 1)*n + j+0] * ((j+1)*dx  +x0 - x)/dx * -(y - y1 + (i+0) * dy)/dy */
+            /*          + ptr[(i + 0)*n + j+1] * (x - (j+0)*dx - x0)/dx * -(y1 - (i+1) * dy - y)/dy */
+            /*          + ptr[(i + 0)*n + j+1] * (x - (j+0)*dx - x0)/dx * -(y - y1 + (i+0) * dy)/dy; */
+
+            double h = ptr[(i + 0)*n + j + 0] * (x_j1 - x)/dx * (y - y_i1)/dy
+                     + ptr[(i + 1)*n + j + 0] * (x_j1 - x)/dx * (y_i0 - y)/dy
+                     + ptr[(i + 0)*n + j + 1] * (x - x_j0)/dx * (y - y_i1)/dy
+                     + ptr[(i + 1)*n + j + 1] * (x - x_j0)/dx * (y_i0 - y)/dy;
+
+            interpolated_points.push_back(std::array<double, 3>{x, y, h});
+
+
+        }
+
+    }
+
+    return interpolated_points;
+
+}
+
 
 PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::PointList>(m, "PointVector", py::buffer_protocol())
@@ -52,6 +138,7 @@ PYBIND11_MODULE(triangulate_dem, m) {
 
     py::bind_vector<std::vector<int>>(m, "IntVector");
     py::bind_vector<std::vector<std::vector<int>>>(m, "ShadowVector");
+
 
     m.def("lindstrom_turk_by_size",
           [] (const rasputin::PointList& raster_coordinates, size_t result_mesh_size) {
@@ -78,20 +165,15 @@ PYBIND11_MODULE(triangulate_dem, m) {
         .def("compute_slopes", &rasputin::compute_slopes,"Compute slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
         .def("compute_aspects", &rasputin::compute_aspects, "Compute aspects for the all the vectors in list.")
         .def("extract_avalanche_expositions", &rasputin::extract_avalanche_expositions, "Extract avalanche exposed cells.")
-        .def("rasterdata_to_pointvector",
-             [] (py::array_t<double> array, double x0, double y0, double x1, double y1, double dx, double dy) {
-                 auto buffer = array.request();
-                 unsigned long M = (unsigned long)buffer.shape[0];
-                 unsigned long N = (unsigned long)buffer.shape[1];
-                 double* ptr = (double*) buffer.ptr;
-
-                 //double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
-
-                 rasputin::PointList raster_coordinates;
-                 raster_coordinates.reserve(M*N);
-                 for (std::size_t i = 0; i < M; ++i)
-                     for (std::size_t j = 0; j < N; ++j)
-                         raster_coordinates.emplace_back(std::array<double, 3>{x0 + j*dx, y1 - i*dy, ptr[i*N + j]});
-                 return raster_coordinates;
-            }, "Pointvector from raster data");
+        .def("constrained2", &interpolate_onto_polygon)
+        .def("constrained3",
+             [] (py::array_t<double> array, double x0, double y0, double x1, double y1, rasputin::PointList boundary, double ratio) {
+             rasputin::PointList pts = rasterdata_to_pointvector(array, x0, y0, x1, y1);
+             rasputin::PointList boundary_pts = interpolate_onto_polygon(array, x0, y0, x1, y1, boundary);
+             return rasputin::constrained(pts, boundary, boundary_pts,
+                                          SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
+                                          SMS::LindstromTurk_placement<CGAL::Mesh>(),
+                                          SMS::LindstromTurk_cost<CGAL::Mesh>());
+             })
+        .def("rasterdata_to_pointvector", &rasterdata_to_pointvector, "Pointvector from raster data");
 }

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -229,6 +229,9 @@ PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::face_vector>(m, "face_vector", py::buffer_protocol())
       .def_buffer(&vecarray_buffer<int, 3>)
       .def("from_numpy", &vecarray_from_numpy<int, 3>);
+    py::bind_vector<rasputin::index_vector>(m, "index_vector", py::buffer_protocol())
+      .def_buffer(&vecarray_buffer<unsigned int, 2>)
+      .def("from_numpy", &vecarray_from_numpy<unsigned int, 2>);
     py::bind_vector<rasputin::double_vector >(m, "double_vector", py::buffer_protocol())
       .def_buffer(&vector_buffer<double>);
 

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -18,6 +18,7 @@ namespace py = pybind11;
 namespace SMS = CGAL::Surface_mesh_simplification;
 
 PYBIND11_MAKE_OPAQUE(rasputin::PointList);
+PYBIND11_MAKE_OPAQUE(rasputin::PointList2D);
 PYBIND11_MAKE_OPAQUE(rasputin::FaceList);
 PYBIND11_MAKE_OPAQUE(rasputin::ScalarList);
 PYBIND11_MAKE_OPAQUE(rasputin::point2_vector);
@@ -44,7 +45,7 @@ rasputin::PointList rasterdata_to_pointvector(py::array_t<double> array, double 
                  int m = buffer.shape[0], n = buffer.shape[1];
                  double* ptr = (double*) buffer.ptr;
 
-                 double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
+                 double dx = (x1 - x0)/(n - 0), dy = (y1 - y0)/(m - 0);
 
                  rasputin::PointList raster_coordinates;
                  raster_coordinates.reserve(m*n);
@@ -54,82 +55,13 @@ rasputin::PointList rasterdata_to_pointvector(py::array_t<double> array, double 
                  return raster_coordinates;
             }
 
-rasputin::PointList interpolate_onto_polygon(py::array_t<double> array, double x0, double y0, double x1, double y1, rasputin::PointList polygon) {
-    auto buffer = array.request();
-    int m = buffer.shape[0], n = buffer.shape[1];
-    double dx = (x1 - x0)/(n - 1), dy = (y1 - y0)/(m - 1);
-    double* ptr = (double*) buffer.ptr;
-
-    auto get_index= [x0,y1,dx,dy](double x, double y) -> std::pair<int, int> {
-        int j = static_cast<int>((x-x0) /dx);
-        int i = static_cast<int>((y1-y) /dy);
-
-        return std::make_pair(i,j);
-    };
-
-    rasputin::PointList interpolated_points;
-    for (std::size_t vertex_number = 0; vertex_number < polygon.size(); ++vertex_number) {
-        rasputin::Point vertex = polygon[vertex_number];
-
-        rasputin::Point second_vertex = polygon[(vertex_number + 1) % polygon.size()];
-
-        // Sample with the same resolution along the polygon edges
-        double edge_len_x = second_vertex[0] - vertex[0];
-        double edge_len_y = second_vertex[1] - vertex[1];
-
-        double edge_len = pow(pow(edge_len_x, 2) + pow(edge_len_y, 2), 0.5);
-
-        // Not including next vertex
-        std::size_t num_samples = static_cast<int>(std::max<double>(std::fabs(edge_len_x/dx), std::fabs(edge_len_y/dy)));
-        double edge_dx = edge_len_x / num_samples;
-        double edge_dy = edge_len_y / num_samples;
-
-        for (std::size_t k=0; k < num_samples; ++k) {
-            double x = vertex[0] + k * edge_dx;
-            double y = vertex[1] + k * edge_dy;
-            auto indices = get_index(x, y);
-
-            int i = indices.first, j = indices.second;
-
-            // Bilinear interpolation
-            // h = h_i_j0 * (x_i1 - x)/dx
-            //   + h_i_j1 * (x - x_i0)/dx
-            //
-            //   = h_i0_j0 * (x_i1 -x)/dx * (yi1 - y)/dy
-            //   + h_i1_j0 * (x_i1 -x)/dx * (y - yi0)/dy
-            //   + ...
-            //   yi0 = y1 -i * dy
-            //   yi1 = y1 -(i+1) * dy
-            double x_j0 = x0 + (j+0) * dx;
-            double x_j1 = x0 + (j+1) * dx;
-            double y_i0 = y1 - (i+0) * dy;
-            double y_i1 = y1 - (i+1) * dy;
-            /* double h = ptr[(i + 0)*n + j+0] * ((j+1)*dx  +x0 - x)/dx * -(y1 - (i+1) * dy - y)/dy */
-            /*          + ptr[(i + 1)*n + j+0] * ((j+1)*dx  +x0 - x)/dx * -(y - y1 + (i+0) * dy)/dy */
-            /*          + ptr[(i + 0)*n + j+1] * (x - (j+0)*dx - x0)/dx * -(y1 - (i+1) * dy - y)/dy */
-            /*          + ptr[(i + 0)*n + j+1] * (x - (j+0)*dx - x0)/dx * -(y - y1 + (i+0) * dy)/dy; */
-
-            double h = ptr[(i + 0)*n + j + 0] * (x_j1 - x)/dx * (y - y_i1)/dy
-                     + ptr[(i + 1)*n + j + 0] * (x_j1 - x)/dx * (y_i0 - y)/dy
-                     + ptr[(i + 0)*n + j + 1] * (x - x_j0)/dx * (y - y_i1)/dy
-                     + ptr[(i + 1)*n + j + 1] * (x - x_j0)/dx * (y_i0 - y)/dy;
-
-            interpolated_points.push_back(std::array<double, 3>{x, y, h});
-
-
-        }
-
-    }
-
-    return interpolated_points;
-
-}
-
 
 PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::PointList>(m, "PointVector", py::buffer_protocol())
         .def_buffer(&vecarray_buffer<double, 3>);
     py::bind_vector<rasputin::point2_vector>(m, "point2_vector", py::buffer_protocol())
+        .def_buffer(&vecarray_buffer<double, 2>);
+    py::bind_vector<rasputin::PointList2D>(m, "PointVector2D", py::buffer_protocol())
         .def_buffer(&vecarray_buffer<double, 2>);
     py::bind_vector<rasputin::FaceList>(m, "FaceVector", py::buffer_protocol())
         .def_buffer(&vecarray_buffer<int, 3>);
@@ -138,7 +70,6 @@ PYBIND11_MODULE(triangulate_dem, m) {
 
     py::bind_vector<std::vector<int>>(m, "IntVector");
     py::bind_vector<std::vector<std::vector<int>>>(m, "ShadowVector");
-
 
     m.def("lindstrom_turk_by_size",
           [] (const rasputin::PointList& raster_coordinates, size_t result_mesh_size) {
@@ -165,15 +96,12 @@ PYBIND11_MODULE(triangulate_dem, m) {
         .def("compute_slopes", &rasputin::compute_slopes,"Compute slopes (i.e. angles relative to xy plane) for the all the vectors in list.")
         .def("compute_aspects", &rasputin::compute_aspects, "Compute aspects for the all the vectors in list.")
         .def("extract_avalanche_expositions", &rasputin::extract_avalanche_expositions, "Extract avalanche exposed cells.")
-        .def("constrained2", &interpolate_onto_polygon)
-        .def("constrained3",
-             [] (py::array_t<double> array, double x0, double y0, double x1, double y1, rasputin::PointList boundary, double ratio) {
-             rasputin::PointList pts = rasterdata_to_pointvector(array, x0, y0, x1, y1);
-             rasputin::PointList boundary_pts = interpolate_onto_polygon(array, x0, y0, x1, y1, boundary);
-             return rasputin::constrained(pts, boundary, boundary_pts,
-                                          SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
-                                          SMS::LindstromTurk_placement<CGAL::Mesh>(),
-                                          SMS::LindstromTurk_cost<CGAL::Mesh>());
+        .def("tin_from_raster",
+             [] (rasputin::RasterData raster, rasputin::PointList2D boundary_vertices, double ratio) {
+             return rasputin::tin_from_raster(raster, boundary_vertices,
+                                              SMS::Count_ratio_stop_predicate<CGAL::Mesh>(ratio),
+                                              SMS::LindstromTurk_placement<CGAL::Mesh>(),
+                                              SMS::LindstromTurk_cost<CGAL::Mesh>());
              })
         .def("rasterdata_to_pointvector", &rasterdata_to_pointvector, "Pointvector from raster data");
 }

--- a/src/rasputin/geo_tiff_reader.py
+++ b/src/rasputin/geo_tiff_reader.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 import argparse
 from logging import getLogger
-import numpy as np
 
 from shapely.geometry import Polygon
 
@@ -11,8 +10,7 @@ from rasputin.reader import read_raster_file, GeoPolygon
 from rasputin.calculate import compute_shade
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio
 from rasputin.triangulate_dem import lindstrom_turk_by_size
-from rasputin.triangulate_dem import surface_normals, orient_tin, compute_slopes
-from rasputin.triangulate_dem import PointVector2D
+from rasputin.triangulate_dem import orient_tin, compute_slopes
 
 
 def geo_tiff_reader():

--- a/src/rasputin/geo_tiff_reader.py
+++ b/src/rasputin/geo_tiff_reader.py
@@ -2,11 +2,12 @@ import sys
 from pathlib import Path
 import argparse
 from logging import getLogger
+import numpy as np
 
 from shapely.geometry import Polygon
 
 from rasputin.writer import write
-from rasputin.reader import read_raster_file
+from rasputin.reader import read_raster_file, GeoPolygon
 from rasputin.calculate import compute_shade
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio
 from rasputin.triangulate_dem import lindstrom_turk_by_size
@@ -53,17 +54,20 @@ def geo_tiff_reader():
     m, n = rasterdata.array.shape
     logger.debug(f"Original: {m * n}")
     logger.critical(rasterdata.info)
+
+    geo_polygon = GeoPolygon(polygon=polygon, proj=None)
+
     if res.ratio:
         if polygon:
             pts, faces = lindstrom_turk_by_ratio(rasterdata._cpp,
-                                                 PointVector2D.from_numpy(polygon.exterior),
+                                                 geo_polygon._cpp,
                                                  res.ratio)
         else:
             pts, faces = lindstrom_turk_by_ratio(rasterdata._cpp, res.ratio)
     else:
         if polygon:
             pts, faces = lindstrom_turk_by_size(rasterdata._cpp,
-                                                PointVector2D.from_numpy(polygon.exterior),
+                                                geo_polygon._cpp,
                                                 res.size)
         else:
             pts, faces = lindstrom_turk_by_size(rasterdata._cpp, res.size)

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -322,7 +322,7 @@ class Rasterdata:
 
     @property
     def _cpp(self):
-        return triangulate_dem.RasterData_float(self.array,
+        return triangulate_dem.raster_data_float(self.array,
                                                 self.x_min, self.y_max,
                                                 self.delta_x, self.delta_y)
 
@@ -464,12 +464,12 @@ class RasterRepository:
 
     def read(self,
              *,
-             target_polygon: GeoPolygon) -> Tuple[triangulate_dem.raster_list, triangulate_dem.simple_polygon]:
+             domain: GeoPolygon) -> Tuple[triangulate_dem.raster_list, triangulate_dem.simple_polygon]:
 
         data = triangulate_dem.raster_list()
-        for part in self.get_intersections(target_polygon=target_polygon):
+        for part in self.get_intersections(target_polygon=domain):
             data.add_raster(part._cpp)
-        cgal_polygon = target_polygon._cpp
+        cgal_polygon = domain._cpp
         return data, cgal_polygon
 
 

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -373,7 +373,8 @@ def read_raster_file(*,
     raster_coordinates = triangulate_dem.rasterdata_to_pointvector(d, x0d, y0d, x1d, y1d)
 
     logger.debug("Done")
-    return raster_coordinates, info
+    #return raster_coordinates, info
+    return d, x0d, y0d, x1d, y1d, info
 
 
 class GeoPolygon:


### PR DESCRIPTION
This pull requests implements the following features:
* Triangulation of (simple) polygonal domains.
* Transfer of raster data to c++ from Python without copying
* Bindings for CGAL polygons

The existing functionality only supports triangulates a convex polygon from a point cloud.
With this pull request, arbitrary (simple) polygons can be triangulated. This works by preserving edges using CGAL's constrained Delaunay triangulation, and filtering out triangles outside the polygonal domain.

In order to preserve edges it is necessary to interpolate new points along the polygonal boundary (otherwise the result will be a badly deformed mesh). To do this efficiently the raster structure needs to be exposed to the c++ layer. This is accomplished using a new `RasterData` struct that can be passed to c++ from Python without making a copy.

CGAL's boolean set operations are used in the interpolation process. Some bindings for CGAL polygon types have been added, since they may be useful for debugging and testing in Python. In particular, CGAL is prone to segfaulting on set operations with incorrectly constructed polygons.

It should be possible to support more complex polygons (i.e. holes or disjoint parts) with relatively minor effort.