### PR TITLE
Corine land cover

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,9 +100,7 @@ setup(
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
     entry_points={
-        'console_scripts': ['rasputin_triangulate = rasputin.geo_tiff_reader:geo_tiff_reader',
-                            'rasputin_web = rasputin.web_visualize:web_visualize',
-                            'rasputin_tin_web = rasputin.web_visualize:visualize_tin',
-                            'rasputin_store_tin = rasputin.application:store_tin']}
+        'console_scripts': ['rasputin_web = rasputin.web_visualize:visualize_tin',
+                            'rasputin_store = rasputin.application:store_tin']}
 )
 

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -128,7 +128,7 @@ def store_tin():
         geo_cell_centers = GeoPoints(xy=np.asarray(tin_cell_centers)[:, :2],
                                      projection=target_coordinate_system)
         #terrain_cover = lc_repo.read_types(land_types=None, geo_points=geo_cell_centers)
-        terrain_cover = corine_repo.read_types(land_types=None,
+        terrain_cover = corine_repo.land_cover(land_types=None,
                                                geo_points=geo_cell_centers,
                                                domain=geo_polygon.polygon)
         terrains = {lt.value: face_vector() for lt in LandCoverType}

--- a/src/rasputin/geo_tiff_reader.py
+++ b/src/rasputin/geo_tiff_reader.py
@@ -6,7 +6,8 @@ from logging import getLogger
 from shapely.geometry import Polygon
 
 from rasputin.writer import write
-from rasputin.reader import read_raster_file, GeoPolygon
+from rasputin.reader import read_raster_file
+from rasputin.geometry import GeoPolygon
 from rasputin.calculate import compute_shade
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio
 from rasputin.triangulate_dem import lindstrom_turk_by_size

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -2,6 +2,7 @@ from typing import Tuple, List, Optional
 import io
 import shutil
 from pathlib import Path
+from pyproj import Proj
 import numpy as np
 from pkg_resources import resource_filename
 from rasputin import triangulate_dem as td
@@ -157,4 +158,11 @@ def write_scene(*, geometries: List[Geometry], output: Path):
         tf.write("const data = {geometries};\n")
 
 
-    pass
+class GeoPoints:
+
+    def __init__(self, *, xy: np.ndarray, projection: Proj) -> None:
+        self.xy = xy
+        assert len(self.xy.shape) == 2 and self.xy.shape[-1] == 2
+        self.projection = projection
+
+

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pyproj import Proj
 import numpy as np
 from pkg_resources import resource_filename
+import pyproj
 from rasputin import triangulate_dem as td
 from rasputin.py2js import point_vector_to_lines, face_and_point_vector_to_lines
 from rasputin.mesh_utils import vertex_field_to_vertex_values
@@ -44,7 +45,7 @@ class Geometry:
     def __init__(self, *,
                  points: td.point3_vector,
                  faces: td.face_vector,
-                 projection: str,
+                 projection: pyproj.Proj,
                  base_color: Optional[Tuple[float, float, float]],
                  material: Optional[str]):
         self.points = points

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -2,7 +2,9 @@ from typing import Tuple, List, Optional
 import io
 import shutil
 from pathlib import Path
+from dataclasses import dataclass
 from pyproj import Proj
+from shapely.geometry import Point
 import numpy as np
 from pkg_resources import resource_filename
 import pyproj
@@ -139,3 +141,8 @@ class GeoPoints:
         self.projection = projection
 
 
+@dataclass
+class GeoPoint:
+
+    point: Point
+    projection: pyproj.Proj

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -9,35 +9,7 @@ import pyproj
 from rasputin import triangulate_dem as td
 from rasputin.py2js import point_vector_to_lines, face_and_point_vector_to_lines
 from rasputin.mesh_utils import vertex_field_to_vertex_values
-
-
-lake_material = """\
-THREE.MeshPhongMaterial( {
-    specular: 0xffffff,
-    shininess: 25,
-    color: 0x006994,
-    reflectivity: 0.3,
-} )
-"""
-
-avalanche_material = """\
-THREE.MeshPhongMaterial( {
-    specular: 0xffffff,
-    shininess: 75,
-    reflectivity: 0.3,
-    vertexColors: THREE.FaceColors
-} )
-"""
-
-terrain_material = """\
-THREE.MeshPhysicalMaterial( {
-    metalness: 0.0,
-    roughness: 0.5,
-    reflectivity: 0.7,
-    clearCoat: 0.0,
-    vertexColors: THREE.FaceColors
-} )
-"""
+from rasputin.material import terrain_material
 
 
 class Geometry:

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -107,6 +107,9 @@ class LandCoverMetaInfo(LandCoverMetaInfoBase):
 
 class GlobCovRepository(LandCoverRepository):
 
+    land_cover_type = LandCoverType
+    land_cover_meta_info_type = LandCoverMetaInfo
+
     def __init__(self, *, path: Path) -> None:
         super().__init__()
         self.path = path / "GLOBCOVER_L4_200901_200912_V2.3.tif"

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -1,17 +1,17 @@
 from typing import List, Optional, Tuple
 from pathlib import Path
-from enum import Enum
 import numpy as np
 from pyproj import Proj, transform
 from PIL import Image
-from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags
+from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags, GeoPolygon
+from rasputin.land_cover_repository import LandCoverBaseType, LandCoverMetaInfoBase, LandCoverRepository
 import rasputin.triangulate_dem as td
 from rasputin.geometry import GeoPoints
 
 Image.MAX_IMAGE_PIXELS = None
 
 
-class LandCoverType(Enum):
+class LandCoverType(LandCoverBaseType):
     crop_type_1 = 11
     crop_type_2 = 14
     crop_type_3 = 20
@@ -36,8 +36,11 @@ class LandCoverType(Enum):
     snow_and_ice = 220
     no_data = 230
 
+
+class LandCoverMetaInfo(LandCoverMetaInfoBase):
+
     @staticmethod
-    def describe(*, land_cover_type="LandCoverType") -> str:
+    def describe(*, land_cover_type=LandCoverType) -> str:
         description = {
             LandCoverType.crop_type_1: "Post-flooding or irrigated croplands (or aquatic)",
             LandCoverType.crop_type_2: "Rainfed croplands",
@@ -64,8 +67,8 @@ class LandCoverType(Enum):
             LandCoverType.no_data: "No data (burnt areas, clouds,…)"}
         return description[land_cover_type]
 
-    @staticmethod
-    def color(*, land_cover_type: "LandCoverType") -> Tuple[int, int, int]:
+    @classmethod
+    def color(cls, *, land_cover_type: LandCoverType) -> Tuple[int, int, int]:
         """Default colors for types in dataset."""
         colors = {
             LandCoverType.crop_type_1: (170, 240, 240),
@@ -95,9 +98,10 @@ class LandCoverType(Enum):
         return colors[land_cover_type]
 
 
-class GlobCovRepository:
+class GlobCovRepository(LandCoverRepository):
 
     def __init__(self, *, path: Path) -> None:
+        super().__init__()
         self.path = path / "GLOBCOVER_L4_200901_200912_V2.3.tif"
         assert self.path.is_file()
         with Image.open(self.path) as image:
@@ -112,13 +116,18 @@ class GlobCovRepository:
     def read(self,
              *,
              land_type: LandCoverType,
-             geo_points: GeoPoints):
-        return self.read_types(land_types=[land_type], geo_points=geo_points)
+             geo_points: GeoPoints,
+             domain: GeoPolygon):
+        return self.land_cover(land_types=[land_type], geo_points=geo_points, domain=domain)
 
-    def read_types(self,
+    def constraints(self, *, domain: GeoPolygon) -> List[GeoPolygon]:
+        return []
+
+    def land_cover(self,
                    *,
                    land_types: Optional[List[LandCoverType]],
-                   geo_points: GeoPoints) -> np.ndarray:
+                   geo_points: GeoPoints,
+                   domain: GeoPolygon) -> np.ndarray:
         target_proj = geo_points.projection
         if target_proj != self.source_proj:
             xy = np.dstack(transform(target_proj, self.source_proj, geo_points.xy[:, 0], geo_points.xy[:, 1]))[0]

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -3,10 +3,10 @@ from pathlib import Path
 import numpy as np
 from pyproj import Proj, transform
 from PIL import Image
-from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags, GeoPolygon
+from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags
 from rasputin.land_cover_repository import LandCoverBaseType, LandCoverMetaInfoBase, LandCoverRepository
 import rasputin.triangulate_dem as td
-from rasputin.geometry import GeoPoints
+from rasputin.geometry import GeoPoints, GeoPolygon
 from rasputin.material import lake_material, terrain_material
 
 Image.MAX_IMAGE_PIXELS = None

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -6,15 +6,9 @@ from pyproj import Proj, transform
 from PIL import Image
 from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags
 import rasputin.triangulate_dem as td
+from rasputin.geometry import GeoPoints
 
 Image.MAX_IMAGE_PIXELS = None
-
-class GeoPoints:
-
-    def __init__(self, *, xy: np.ndarray, projection: Proj) -> None:
-        self.xy = xy
-        assert self.xy.shape[-1] == 2
-        self.projection = projection
 
 
 class LandCoverType(Enum):
@@ -157,6 +151,4 @@ class GlobCovRepository:
         func = np.vectorize(lambda t: t not in lcts)
         all_land_types[func(all_land_types)] = 0
         return all_land_types
-
-
 

--- a/src/rasputin/globcov_repository.py
+++ b/src/rasputin/globcov_repository.py
@@ -7,6 +7,7 @@ from rasputin.reader import extract_geo_keys, GeoKeysInterpreter, GeoTiffTags, G
 from rasputin.land_cover_repository import LandCoverBaseType, LandCoverMetaInfoBase, LandCoverRepository
 import rasputin.triangulate_dem as td
 from rasputin.geometry import GeoPoints
+from rasputin.material import lake_material, terrain_material
 
 Image.MAX_IMAGE_PIXELS = None
 
@@ -39,8 +40,8 @@ class LandCoverType(LandCoverBaseType):
 
 class LandCoverMetaInfo(LandCoverMetaInfoBase):
 
-    @staticmethod
-    def describe(*, land_cover_type=LandCoverType) -> str:
+    @classmethod
+    def describe(cls, *, land_cover_type=LandCoverType) -> str:
         description = {
             LandCoverType.crop_type_1: "Post-flooding or irrigated croplands (or aquatic)",
             LandCoverType.crop_type_2: "Rainfed croplands",
@@ -66,6 +67,12 @@ class LandCoverMetaInfo(LandCoverMetaInfoBase):
             LandCoverType.snow_and_ice: "Permanent snow and ice",
             LandCoverType.no_data: "No data (burnt areas, clouds,…)"}
         return description[land_cover_type]
+
+    @classmethod
+    def material(cls, *, land_cover_type: LandCoverBaseType) -> str:
+        if land_cover_type == LandCoverType.water:
+            return lake_material
+        return terrain_material
 
     @classmethod
     def color(cls, *, land_cover_type: LandCoverType) -> Tuple[int, int, int]:

--- a/src/rasputin/gml_repository.py
+++ b/src/rasputin/gml_repository.py
@@ -8,6 +8,7 @@ from shapely.geometry import Polygon, Point
 from rasputin.geometry import GeoPoints
 from rasputin.land_cover_repository import LandCoverBaseType, LandCoverRepository, LandCoverMetaInfoBase
 from rasputin.reader import GeoPolygon
+from rasputin.material import lake_material, terrain_material
 
 
 class LandCoverType(LandCoverBaseType):
@@ -115,9 +116,15 @@ class LandCoverMetaInfo(LandCoverMetaInfoBase):
                 522: (166, 255, 230),
                 523: (230, 242, 255)}[land_cover_type.value]
 
-    @staticmethod
-    def describe(*, land_cover_type=LandCoverType) -> str:
+    @classmethod
+    def describe(cls, *, land_cover_type=LandCoverType) -> str:
         return ""
+
+    @classmethod
+    def material(cls, *, land_cover_type=LandCoverType) -> str:
+        if land_cover_type.value > 500:
+            return lake_material
+        return terrain_material
 
 
 class GMLRepository(LandCoverRepository):
@@ -182,7 +189,7 @@ class GMLRepository(LandCoverRepository):
         else:
             xy = geo_points.xy
 
-        land_cover_types = self.read(domain.buffer(10).convex_hull)
+        land_cover_types = self.read(domain.buffer(50))
 
         # TODO: Move to C++ for speed!
         faces = np.zeros(len(xy), dtype="int")

--- a/src/rasputin/land_cover_repository.py
+++ b/src/rasputin/land_cover_repository.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+from abc import ABC, abstractmethod
+from enum import Enum
+import numpy as np
+from rasputin.reader import GeoPolygon
+from rasputin.geometry import GeoPoints
+
+
+class LandCoverTypeBase(ABC, Enum):
+    pass
+
+
+class LandCoverRepository(ABC):
+
+    @abstractmethod
+    def constraints(self, *, domain: GeoPolygon) -> List[GeoPolygon]:
+        pass
+
+    @abstractmethod
+    def land_cover(self, *,
+                   land_cover_types: Optional[List[LandCoverTypeBase]],
+                   geo_points: GeoPoints,
+                   domain: GeoPolygon) -> np.ndarray:
+        pass

--- a/src/rasputin/land_cover_repository.py
+++ b/src/rasputin/land_cover_repository.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from abc import ABC, abstractmethod
 from enum import Enum
 import numpy as np
@@ -6,8 +6,21 @@ from rasputin.reader import GeoPolygon
 from rasputin.geometry import GeoPoints
 
 
-class LandCoverTypeBase(ABC, Enum):
+class LandCoverBaseType(Enum):
     pass
+
+
+class LandCoverMetaInfoBase(ABC):
+
+    @classmethod
+    @abstractmethod
+    def color(cls, *, land_cover_type: LandCoverBaseType) -> Tuple[int, int, int]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def describe(cls, *, land_cover_type: LandCoverBaseType) -> str:
+        pass
 
 
 class LandCoverRepository(ABC):
@@ -17,8 +30,10 @@ class LandCoverRepository(ABC):
         pass
 
     @abstractmethod
-    def land_cover(self, *,
-                   land_cover_types: Optional[List[LandCoverTypeBase]],
+    def land_cover(self,
+                   *,
+                   land_cover_types: Optional[List[LandCoverBaseType]],
                    geo_points: GeoPoints,
                    domain: GeoPolygon) -> np.ndarray:
         pass
+

--- a/src/rasputin/land_cover_repository.py
+++ b/src/rasputin/land_cover_repository.py
@@ -2,8 +2,7 @@ from typing import List, Optional, Tuple
 from abc import ABC, abstractmethod
 from enum import Enum
 import numpy as np
-from rasputin.reader import GeoPolygon
-from rasputin.geometry import GeoPoints
+from rasputin.geometry import GeoPoints, GeoPolygon
 
 
 class LandCoverBaseType(Enum):

--- a/src/rasputin/land_cover_repository.py
+++ b/src/rasputin/land_cover_repository.py
@@ -22,6 +22,10 @@ class LandCoverMetaInfoBase(ABC):
     def describe(cls, *, land_cover_type: LandCoverBaseType) -> str:
         pass
 
+    @classmethod
+    @abstractmethod
+    def material(cls, *, land_cover_type: LandCoverBaseType) -> str:
+        pass
 
 class LandCoverRepository(ABC):
 

--- a/src/rasputin/land_cover_repository.py
+++ b/src/rasputin/land_cover_repository.py
@@ -29,6 +29,16 @@ class LandCoverMetaInfoBase(ABC):
 
 class LandCoverRepository(ABC):
 
+    @property
+    @abstractmethod
+    def land_cover_type(self) -> LandCoverBaseType:
+        pass
+
+    @property
+    @abstractmethod
+    def land_cover_meta_info_type(self) -> LandCoverMetaInfoBase:
+        pass
+
     @abstractmethod
     def constraints(self, *, domain: GeoPolygon) -> List[GeoPolygon]:
         pass

--- a/src/rasputin/material.py
+++ b/src/rasputin/material.py
@@ -1,0 +1,28 @@
+lake_material = """\
+THREE.MeshPhongMaterial( {
+    specular: 0xffffff,
+    shininess: 25,
+    color: 0x006994,
+    reflectivity: 0.3,
+} )
+"""
+
+avalanche_material = """\
+THREE.MeshPhongMaterial( {
+    specular: 0xffffff,
+    shininess: 75,
+    reflectivity: 0.3,
+    vertexColors: THREE.FaceColors
+} )
+"""
+
+terrain_material = """\
+THREE.MeshPhysicalMaterial( {
+    metalness: 0.0,
+    roughness: 0.5,
+    reflectivity: 0.7,
+    clearCoat: 0.0,
+    vertexColors: THREE.FaceColors
+} )
+"""
+

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -66,7 +66,7 @@ class TinRepository:
                 else:
                     points, faces = geom.points, geom.faces
                 h5_points = grp.create_dataset(name="points", data=np.asarray(points), dtype="d")
-                h5_points.attrs["projection"] = geom.projection
+                h5_points.attrs["projection"] = geom.projection.definition_string()
                 h5_faces = grp.create_dataset(name="faces", data=np.asarray(faces), dtype="i")
                 h5_faces.attrs["color"] = geom.base_color
 

--- a/src/rasputin/web_visualize.py
+++ b/src/rasputin/web_visualize.py
@@ -8,9 +8,9 @@ import argparse
 from rasputin.tin_repository import TinRepository
 from rasputin import triangulate_dem
 from rasputin.reader import RasterRepository
-from rasputin.globcov_repository import GlobCovRepository, GeoPoints, LandCoverType
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio
-from rasputin.geometry import Geometry, write_scene, avalanche_material, lake_material, terrain_material
+from rasputin.geometry import Geometry, write_scene
+from rasputin.material import avalanche_material, lake_material, terrain_material
 from rasputin import avalanche
 from rasputin.avalanche import varsom_angles
 

--- a/src/rasputin/writer.py
+++ b/src/rasputin/writer.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Dict, Any
+from typing import List, Tuple, Dict, Any
 from pathlib import Path
 import numpy as np
 from meshio import XdmfTimeSeriesWriter, write_points_cells

--- a/tests/test_gml_repository.py
+++ b/tests/test_gml_repository.py
@@ -5,7 +5,8 @@ import pyproj
 from shapely.geometry import Polygon
 from rasputin.geometry import GeoPoints
 from rasputin.gml_repository import GMLRepository, LandCoverType
-from rasputin.reader import RasterRepository, GeoPolygon
+from rasputin.geometry import GeoPolygon
+from rasputin.reader import RasterRepository
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio, cell_centers
 from descartes import PolygonPatch
 import matplotlib.pyplot as plt
@@ -22,7 +23,7 @@ def test_gml_repository():
     y = np.array([60.55, 60.55, 60.50, 60.50])
 
     x, y = pyproj.transform(input_coordinate_system, target_coordinate_system, x, y)
-    domain = Polygon(shell=list(zip(x, y)))
+    domain = GeoPolygon(polygon=Polygon(shell=list(zip(x, y))), projection=target_coordinate_system)
 
     repos = GMLRepository(path=path)
     plot = False
@@ -39,8 +40,9 @@ def test_gml_repository():
         plt.show()
 
     dem_archive = Path(os.environ["RASPUTIN_DATA_DIR"]) / "dem_archive"
-    geo_polygon = GeoPolygon(polygon=domain, proj=target_coordinate_system)
-    raster_data_list, cpp_polygon = RasterRepository(directory=dem_archive).read(domain=geo_polygon)
+    rr = RasterRepository(directory=dem_archive)
+    raster_domain = domain.transform(target_projection=pyproj.Proj(rr.coordinate_system()))
+    raster_data_list, cpp_polygon = rr.read(domain=raster_domain)
     points, faces = lindstrom_turk_by_ratio(raster_data_list,
                                             cpp_polygon,
                                             0.1)

--- a/tests/test_gml_repository.py
+++ b/tests/test_gml_repository.py
@@ -18,8 +18,8 @@ def test_gml_repository():
     input_coordinate_system = pyproj.Proj(init="EPSG:4326")
     target_coordinate_system = pyproj.Proj(init="EPSG:32633")
 
-    x = np.array([8.5, 8.6, 8.6, 8.5])
-    y = np.array([60.55, 60.55, 60.35, 60.35])
+    x = np.array([8.5, 8.52, 8.52, 8.5])
+    y = np.array([60.55, 60.55, 60.50, 60.50])
 
     x, y = pyproj.transform(input_coordinate_system, target_coordinate_system, x, y)
     domain = Polygon(shell=list(zip(x, y)))
@@ -43,10 +43,9 @@ def test_gml_repository():
     raster_data_list, cpp_polygon = RasterRepository(directory=dem_archive).read(domain=geo_polygon)
     points, faces = lindstrom_turk_by_ratio(raster_data_list,
                                             cpp_polygon,
-                                            1.1)
+                                            0.1)
     tin_cell_centers = cell_centers(points, faces)
     geo_cell_centers = GeoPoints(xy=np.asarray(tin_cell_centers)[:, :2],
                                  projection=target_coordinate_system)
-    terrain_cover = repos.read_types(land_types=None, geo_points=geo_cell_centers, domain=domain)
+    terrain_cover = repos.land_cover(land_types=None, geo_points=geo_cell_centers, domain=domain)
     assert terrain_cover is not None
-    #tr = TinRepository(path=tin_archive)

--- a/tests/test_land_cover_repository.py
+++ b/tests/test_land_cover_repository.py
@@ -33,7 +33,7 @@ def test_extract_land_types():
 def test_construct_triangulation_with_land_types():
     assert "RASPUTIN_DATA_DIR" in os.environ
     data_dir = Path(os.environ["RASPUTIN_DATA_DIR"])
-    lt_repo = GlobCovRepository(path=data_dir/ "globcov")
+    lt_repo = GlobCovRepository(path=data_dir / "globcov")
     dem_repo = RasterRepository(directory=data_dir / "dem_archive")
     x0 = 8.54758671814368
     y0 = 60.898468
@@ -50,6 +50,8 @@ def test_construct_triangulation_with_land_types():
     points, faces = td.lindstrom_turk_by_ratio(raster_data_list,
                                                cpp_polygon,
                                                1.1)
+    assert len(faces)
+    assert len(points)
     centers = np.asarray(td.cell_centers(points, faces))[:, :2]
     land_types = lt_repo.land_cover(land_types=None,
                                     geo_points=GeoPoints(xy=centers,

--- a/tests/test_land_cover_repository.py
+++ b/tests/test_land_cover_repository.py
@@ -24,7 +24,7 @@ def test_extract_land_types():
     path = Path('/Users/skavhaug/projects/rasputin_data/globcov')
     xy = np.array([[8, 60], [8.1, 61]], dtype='d')
     proj = Proj(init="EPSG:4326")
-    domain = GeoPolygon(proj=proj, polygon=Polygon())
+    domain = GeoPolygon(projection=proj, polygon=Polygon())
     geo_points = GeoPoints(xy=xy, projection=proj)
     gcr = GlobCovRepository(path=path)
     gcr.read(land_type=LandCoverType.crop_type_2, geo_points=geo_points, domain=domain)
@@ -43,9 +43,8 @@ def test_construct_triangulation_with_land_types():
                                   xmax=x0 + 0.01,
                                   ymin=y0 - 0.01,
                                   ymax=y0 + 0.01)
-    domain = GeoPolygon(polygon=polygon, proj=input_coordinate_system)
-    target_domain = GeoPolygon(polygon=Polygon(), proj=target_coordinate_system)
-    domain = target_domain._to_my_proj(domain)
+    domain = GeoPolygon(polygon=polygon,
+                        projection=input_coordinate_system).transform(target_projection=target_coordinate_system)
     raster_data_list, cpp_polygon = dem_repo.read(domain=domain)
     points, faces = td.lindstrom_turk_by_ratio(raster_data_list,
                                                cpp_polygon,

--- a/tests/test_raster_repository.py
+++ b/tests/test_raster_repository.py
@@ -2,87 +2,21 @@ import pytest
 from pathlib import Path
 import os
 import pyproj
+from shapely.geometry import Polygon
+from rasputin.reader import GeoPolygon
 from rasputin.reader import RasterRepository
 
-if "RASPUTIN_DATA_DIR" in os.environ:
-    data_dir = Path(os.environ["RASPUTIN_DATA_DIR"])
-else:
-    data_dir = Path(os.environ["HOME"]) /"projects" / "rasputin_data" / "dem_archive"
+assert "RASPUTIN_DATA_DIR" in os.environ, "You need to set RASPUTIN_DATA_DIR prior to running this test"
+data_dir = os.environ["RASPUTIN_DATA_DIR"]
 
 
-@pytest.mark.skip
 def test_get():
-    #x0 = 8.530918
     x0 = 8.54758671814368
     y0 = 60.898468
-    repo = RasterRepository(directory=data_dir)
+    repo = RasterRepository(directory=Path(data_dir))
     input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
-    target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
-    result = repo.read(x=x0,
-                       y=y0,
-                       dx=210,
-                       dy=210,
-                       input_coordinate_system=input_coordinate_system,
-                       target_coordinate_system=target_coordinate_system)
+    #target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
+    polygon = Polygon.from_bounds(xmin=x0 - 0.1, xmax=x0 + 0.1, ymin=y0 - 0.1, ymax=y0 + 0.1)
+    geo_polygon = GeoPolygon(proj=input_coordinate_system, polygon=polygon)
+    result = repo.read(domain=geo_polygon)
     assert result
-
-
-
-def test_run():
-    from descartes import PolygonPatch
-    import matplotlib.pyplot as plt
-    from pathlib import Path
-    import os
-    import pyproj
-    from rasputin.reader import RasterRepository
-    if "RASPUTIN_DATA_DIR" in os.environ:
-        data_dir = Path(os.environ["RASPUTIN_DATA_DIR"])
-    else:
-        data_dir = Path(os.environ["HOME"]) /"projects" / "rasputin_data" / "dem_archive"
-
-    x0 = 8.54550
-    y0 = 60.9
-    repo = RasterRepository(directory=data_dir)
-    input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
-    target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
-    result = repo.read(x=x0,
-                       y=y0,
-                       dx=50,
-                       dy=5.0,
-                       input_coordinate_system=input_coordinate_system,
-                       target_coordinate_system=target_coordinate_system)
-
-    print([r for r in result])
-
-    xbound = repo.shapes["target_bbox"].bounds[0::2]
-    ybound = repo.shapes["target_bbox"].bounds[1::2]
-
-    f1 = "/Users/skavhaug/projects/rasputin_data/dem_archive/6701_1_10m_z33.tif"
-    f2 = "/Users/skavhaug/projects/rasputin_data/dem_archive/6701_4_10m_z33.tif"
-    i1 = repo.shapes.get(f"{f1}_intersection", None)
-    i2 = repo.shapes.get(f"{f2}_intersection", None)
-
-    r1 = repo.shapes.get(f"{f1}_remainding_bbox")
-    r2 = repo.shapes.get(f"{f2}_remainding_bbox")
-
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
-
-    if i1:
-        ax.add_patch(PolygonPatch(i1, fc="red", alpha=0.5))
-    if i2:
-        ax.add_patch(PolygonPatch(i2, fc="blue", alpha=0.5))
-    ax.set_xbound(*xbound)
-    ax.set_ybound(*ybound)
-
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
-
-    if r1:
-        ax.add_patch(PolygonPatch(r1, fc="green", alpha=0.5))
-    if r2:
-        ax.add_patch(PolygonPatch(r2, fc="yellow", alpha=0.5))
-    ax.set_xbound(*xbound)
-    ax.set_ybound(*ybound)
-
-    plt.show()

--- a/tests/test_raster_repository.py
+++ b/tests/test_raster_repository.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import os
 import pyproj
 from shapely.geometry import Polygon
-from rasputin.reader import GeoPolygon
+from rasputin.geometry import GeoPolygon
 from rasputin.reader import RasterRepository
 
 assert "RASPUTIN_DATA_DIR" in os.environ, "You need to set RASPUTIN_DATA_DIR prior to running this test"
@@ -17,6 +17,6 @@ def test_get():
     input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
     #target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
     polygon = Polygon.from_bounds(xmin=x0 - 0.1, xmax=x0 + 0.1, ymin=y0 - 0.1, ymax=y0 + 0.1)
-    geo_polygon = GeoPolygon(proj=input_coordinate_system, polygon=polygon)
+    geo_polygon = GeoPolygon(projection=input_coordinate_system, polygon=polygon)
     result = repo.read(domain=geo_polygon)
     assert result

--- a/tests/test_tin_repository.py
+++ b/tests/test_tin_repository.py
@@ -1,48 +1,71 @@
 import pytest
 from tempfile import TemporaryDirectory
 from pathlib import Path
-from rasputin.triangulate_dem import PointVector, FaceVector
+from rasputin.triangulate_dem import point3_vector, face_vector
 from rasputin.tin_repository import TinRepository
+from rasputin.geometry import Geometry
+from pyproj import Proj
 
 @pytest.fixture
 def tin():
-    pts = PointVector([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
-    faces = FaceVector([[0, 1, 2]])
+    pts = point3_vector([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    faces = face_vector([[0, 1, 2]])
     return pts, faces
 
 
 def test_store_tin(tin):
     pts, faces = tin
     uid = "test_tin"
+    proj = Proj(init="EPSG:32633")
+    geom_tag = "test_geom"
+    geom = {geom_tag: Geometry(points=pts,
+                                  faces=faces,
+                                  projection=proj,
+                                  base_color=(0, 0, 0),
+                                  material="dummy2")}
     with TemporaryDirectory() as directory:
         archive = Path(directory)
         tr = TinRepository(path=archive)
-        tr.save(points=pts, faces=faces, uid=uid)
+        tr.save(uid=uid, geometries=geom)
         assert uid in tr.content
-        assert tr.content[uid]["num_points"] == len(pts)
-        assert tr.content[uid]["num_faces"] == len(faces)
+        print(tr.content[uid])
+        geom_info = tr.content[uid]["tins"][geom_tag]
+        assert geom_info["num_points"] == len(pts)
+        assert geom_info["num_faces"] == len(faces)
         assert "timestamp" in tr.content[uid]
-        assert "projection" in tr.content[uid]
+        assert "projection" in geom_info
 
 
 def test_store_and_load_tin(tin):
     pts, faces = tin
     uid = "test_tin"
+    proj = Proj(init="EPSG:32633")
+    geom = {"test_geom": Geometry(points=pts,
+                                  faces=faces,
+                                  projection=proj,
+                                  base_color=(0,0,0),
+                                  material="dummy2")}
     with TemporaryDirectory() as directory:
         archive = Path(directory)
         tr = TinRepository(path=archive)
-        tr.save(points=pts, faces=faces, uid=uid)
-        pts2, faces2 = tr.read(uid=uid)
-        assert pts2 == pts
-        assert faces2 == faces
+        tr.save(uid=uid, geometries=geom)
+        geom = tr.read(uid=uid)["test_geom"]
+        assert geom.points == pts
+        assert geom.faces == faces
 
 def test_store_and_delete_tin(tin):
     pts, faces = tin
     uid = "test_tin"
+    proj = Proj(init="EPSG:32633")
+    geom = {"test_geom": Geometry(points=pts,
+                                  faces=faces,
+                                  projection=proj,
+                                  base_color=(0,0,0),
+                                  material="dummy2")}
     with TemporaryDirectory() as directory:
         archive = Path(directory)
         tr = TinRepository(path=archive)
-        tr.save(points=pts, faces=faces, uid=uid)
+        tr.save(uid=uid, geometries=geom)
         tr.delete(uid=uid)
         assert uid not in tr.content
         assert not (archive / f"{uid}.h5").exists()


### PR DESCRIPTION
This PR adds a reader for corine data in the form of gml and adds the terrain types to the tin based on what kind of terrain the center point of a cell belongs to. It also adds the `-polyfile` command argument for `rasputin_tin` and `-target-coordinate-system` which accepts a `EMPS:<id>` argument id. Finally, the `-land-type-partition` now accepts either `corine` or `globcov`.