### PR TITLE
Coordinate system fix

### DIFF
--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -106,7 +106,6 @@ def store_tin():
                                             cpp_polygon,
                                             res.ratio)
     assert len(points), "No tin extracted, something went wrong..."
-    print(len(points), len(faces))
     p = np.asarray(points)
     x, y, z = pyproj.transform(raster_coordinate_system,
                                target_coordinate_system,

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -96,12 +96,11 @@ def store_tin():
         source_polygon = Polygon((x, y) for (x, y) in zip(res.x, res.y))
 
     raster_repo = RasterRepository(directory=dem_archive)
-    raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system())
     target_coordinate_system = pyproj.Proj(init=res.target_coordinate_system)
     input_domain = GeoPolygon(polygon=source_polygon, projection=pyproj.Proj(init="EPSG:4326"))
     target_domain = input_domain.transform(target_projection=target_coordinate_system)
+    raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system(domain=target_domain))
     raster_domain = input_domain.transform(target_projection=raster_coordinate_system)
-
     raster_data_list, cpp_polygon = raster_repo.read(domain=raster_domain)
     points, faces = lindstrom_turk_by_ratio(raster_data_list,
                                             cpp_polygon,

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -417,9 +417,13 @@ class RasterRepository:
                     break
         return parts
 
-    def coordinate_system(self) -> str:
-        filepath = next(self.directory.glob("*.tif"))
-        return GeoPolygon.from_raster_file(filepath=filepath).projection.definition_string()
+    def coordinate_system(self, domain: GeoPolygon) -> str:
+        raster_files = self.directory.glob("*.tif")
+        for filepath in raster_files:
+            geo_polygon = GeoPolygon.from_raster_file(filepath=filepath)
+            if domain.intersects(geo_polygon):
+                return geo_polygon.projection.definition_string()
+        return ""
 
     def read(self,
              *,

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -145,8 +145,8 @@ def get_image_bounds(image: TiffImageFile) -> tuple:
 
     x_min = x_tag - delta_x * j_tag
     y_max = y_tag + delta_y * i_tag
-    x_max = x_tag + delta_x * (n - 1 - j_tag)
-    y_min = y_tag - delta_y * (m - 1 - i_tag)
+    x_max = x_tag + delta_x * (m - 1 - j_tag)
+    y_min = y_tag - delta_y * (n - 1 - i_tag)
 
     return (x_min, y_min, x_max, y_max)
 
@@ -423,7 +423,7 @@ class RasterRepository:
             geo_polygon = GeoPolygon.from_raster_file(filepath=filepath)
             if domain.intersects(geo_polygon):
                 return geo_polygon.projection.definition_string()
-        return ""
+        raise RuntimeError("Defining polygon does not intersect with dem raster data.")
 
     def read(self,
              *,

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -354,8 +354,8 @@ def read_raster_file(*,
         x_min = x_tag - delta_x * j_tag
         y_max = y_tag + delta_y * i_tag
 
-        x_max = x_tag + delta_x * (n - 1 - j_tag)
-        y_min = y_tag - delta_y * (m - 1 - i_tag)
+        x_max = x_tag + delta_x * (m - 1 - j_tag)
+        y_min = y_tag - delta_y * (n - 1 - i_tag)
 
         # If polygon is provided we crop the raster image to the polygon
         if polygon:
@@ -368,9 +368,9 @@ def read_raster_file(*,
 
             # Find indices for the box
             x_min_p, y_min_p, x_max_p, y_max_p = polygon.bounds
-            box = (np.clip(np.floor((x_min_p - x_min)/delta_x), 0, n-1),
+            box = (np.clip(np.floor((x_min_p - x_min)/delta_x), 0, m-1),
                    np.clip(np.floor((y_max - y_max_p)/delta_y), 0, n-1),
-                   np.clip(np.ceil((x_max_p - x_min)/delta_x) + 1, 1, n),
+                   np.clip(np.ceil((x_max_p - x_min)/delta_x) + 1, 1, m),
                    np.clip(np.ceil((y_max - y_min_p)/delta_y) + 1, 1, n))
 
             # NOTE: Cropping does not include last indices
@@ -423,6 +423,7 @@ class RasterRepository:
             geo_polygon = GeoPolygon.from_raster_file(filepath=filepath)
             if domain.intersects(geo_polygon):
                 return geo_polygon.projection.definition_string()
+
         raise RuntimeError("Defining polygon does not intersect with dem raster data.")
 
     def read(self,
@@ -440,4 +441,4 @@ def read_sun_posisions(*, filepath: Path) -> triangulate_dem.shadow_vector:
     assert filepath.exists()
     with filepath.open("r") as ff:
         pass
-    return triangulate_dem.ShadowVector()
+    return triangulate_dem.shadow_vector()

--- a/tests/test_gml_repository.py
+++ b/tests/test_gml_repository.py
@@ -41,7 +41,7 @@ def test_gml_repository():
 
     dem_archive = Path(os.environ["RASPUTIN_DATA_DIR"]) / "dem_archive"
     rr = RasterRepository(directory=dem_archive)
-    raster_domain = domain.transform(target_projection=pyproj.Proj(rr.coordinate_system()))
+    raster_domain = domain.transform(target_projection=pyproj.Proj(rr.coordinate_system(domain=domain)))
     raster_data_list, cpp_polygon = rr.read(domain=raster_domain)
     points, faces = lindstrom_turk_by_ratio(raster_data_list,
                                             cpp_polygon,

--- a/tests/test_tin_repository.py
+++ b/tests/test_tin_repository.py
@@ -53,6 +53,7 @@ def test_store_and_load_tin(tin):
         assert geom.points == pts
         assert geom.faces == faces
 
+
 def test_store_and_delete_tin(tin):
     pts, faces = tin
     uid = "test_tin"


### PR DESCRIPTION
This PR fixes the case when several dems in different coordinate systems are in the dem archive. However, we still assume that for a given constraining polygon, all dems have the same projection.

Also a couple of minor bugs is removed, related to computing the boundary of a given raster file.