### PR TITLE
Implement a Mesh class

### DIFF
--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -10,8 +10,9 @@ import argparse
 
 from rasputin.reader import RasterRepository
 from rasputin.tin_repository import TinRepository
-from rasputin.triangulate_dem import lindstrom_turk_by_ratio, cell_centers, face_vector, point3_vector
+from rasputin.triangulate_dem import cell_centers, face_vector, point3_vector
 from rasputin.geometry import Geometry, GeoPoints, GeoPolygon
+from rasputin.mesh import Mesh
 
 from rasputin import gml_repository
 from rasputin import globcov_repository
@@ -103,13 +104,14 @@ def store_tin():
     target_coordinate_system = pyproj.Proj(init=res.target_coordinate_system)
     target_domain = input_domain.transform(target_projection=target_coordinate_system)
 
+    raster_repo = RasterRepository(directory=dem_archive)
     raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system(domain=target_domain))
     raster_domain = input_domain.transform(target_projection=raster_coordinate_system)
 
-    raster_data_list = RasterRepository(directory=dem_archive).read(domain=geo_polygon)
+    raster_data_list = raster_repo.read(domain=raster_domain)
 
     mesh = (Mesh.from_raster(data=raster_data_list,
-                             domain=geo_polygon)
+                             domain=raster_domain)
             .simplify(ratio=res.ratio))
 
     points, faces = mesh.points, mesh.faces

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -57,7 +57,7 @@ def store_tin():
                             default="",
                             choices=["corine", "globcov"],
                             help="Partition mesh by land type")
-    arg_parser.add_argument("--transpose", action="store_true", help="Use the transpose of the raster image")
+    arg_parser.add_argument("-transpose", action="store_true", help="Use the transpose of the raster image")
     arg_parser.add_argument("uid", type=str, help="Unique ID for the result TIN")
     res = arg_parser.parse_args(sys.argv[1:])
 
@@ -95,7 +95,8 @@ def store_tin():
     target_coordinate_system = pyproj.Proj(init=res.target_coordinate_system)
     target_domain = input_domain.transform(target_projection=target_coordinate_system)
 
-    raster_repo = RasterRepository(directory=dem_archive, transpose=res.transpose)
+    # The transpose is probably flipped in the logic, so negating it should give correct behaviour.
+    raster_repo = RasterRepository(directory=dem_archive, transpose=not res.transpose)
     raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system(domain=target_domain))
     raster_domain = input_domain.transform(target_projection=raster_coordinate_system)
 

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -101,6 +101,8 @@ def store_tin():
 
     target_coordinate_system = pyproj.Proj(init=res.target_coordinate_system)
     target_domain = input_domain.transform(target_projection=target_coordinate_system)
+    print(target_domain.projection.definition_string())
+    print(target_domain.polygon.bounds)
 
     raster_repo = RasterRepository(directory=dem_archive)
     raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system(domain=target_domain))
@@ -113,6 +115,12 @@ def store_tin():
             .simplify(ratio=res.ratio))
 
     points, faces = mesh.points, mesh.faces
+    print(points[:,0].min())
+    print(points[:,0].max())
+    print(points[:,1].min())
+    print(points[:,1].max())
+    print(points[:,2].min())
+    print(points[:,2].max())
 
     assert len(points), "No tin extracted, something went wrong..."
     x, y, z = pyproj.transform(raster_coordinate_system,

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -32,7 +32,6 @@ from rasputin.tin_repository import TinRepository
 from rasputin.triangulate_dem import extract_lakes, cell_centers, face_vector
 from rasputin.geometry import Geometry, write_scene, lake_material, terrain_material
 from rasputin.globcov_repository import GlobCovRepository, GeoPoints, LandCoverType
->>>>>>> Update python interface for new functionality
 
 
 def store_tin():

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -7,7 +7,7 @@ import pyproj
 from shapely.geometry import Polygon
 from shapely import wkt, wkb
 import argparse
-<<<<<<< HEAD
+
 from rasputin.reader import RasterRepository
 from rasputin.tin_repository import TinRepository
 from rasputin.triangulate_dem import lindstrom_turk_by_ratio, cell_centers, face_vector, point3_vector
@@ -25,13 +25,6 @@ def read_poly_file(*, path: Path) -> Polygon:
         with path.open("r") as pfile:
             polygon = wkt.loads(pfile.read())
     return polygon
-=======
-from rasputin.reader import RasterRepository, GeoPolygon
-from rasputin.mesh import Mesh
-from rasputin.tin_repository import TinRepository
-from rasputin.triangulate_dem import extract_lakes, cell_centers, face_vector
-from rasputin.geometry import Geometry, write_scene, lake_material, terrain_material
-from rasputin.globcov_repository import GlobCovRepository, GeoPoints, LandCoverType
 
 
 def store_tin():

--- a/src/rasputin/application.py
+++ b/src/rasputin/application.py
@@ -51,12 +51,14 @@ def store_tin():
     arg_parser.add_argument("-polyfile", type=str, help="Polygon definition in WKT or WKB format", default="")
     arg_parser.add_argument("-target-coordinate-system", type=str, default="EPSG:32633", help="Target coordinate system")
     arg_parser.add_argument("-ratio", type=float, default=0.4, help="Mesh coarsening factor in [0, 1]")
+
     arg_parser.add_argument("-override", action="store_true", help="Replace existing archive entry")
     arg_parser.add_argument("-land-type-partition",
                             type=str,
                             default="",
                             choices=["corine", "globcov"],
                             help="Partition mesh by land type")
+    arg_parser.add_argument("--transpose", action="store_true", help="Use the transpose of the raster image")
     arg_parser.add_argument("uid", type=str, help="Unique ID for the result TIN")
     res = arg_parser.parse_args(sys.argv[1:])
 
@@ -96,7 +98,7 @@ def store_tin():
     print(target_domain.projection.definition_string())
     print(target_domain.polygon.bounds)
 
-    raster_repo = RasterRepository(directory=dem_archive)
+    raster_repo = RasterRepository(directory=dem_archive, transpose=res.transpose)
     raster_coordinate_system = pyproj.Proj(raster_repo.coordinate_system(domain=target_domain))
     raster_domain = input_domain.transform(target_projection=raster_coordinate_system)
 

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -269,7 +269,7 @@ PYBIND11_MODULE(triangulate_dem, m) {
         .def("intersection", &intersect_polygons<CGAL::SimplePolygon, CGAL::SimplePolygon>)
         .def("intersection", &intersect_polygons<CGAL::SimplePolygon, CGAL::Polygon>);
 
-    py::class_<CGAL::Polygon, std::unique_ptr<CGAL::Polygon>>(m, "Polygon")
+    py::class_<CGAL::Polygon, std::unique_ptr<CGAL::Polygon>>(m, "polygon")
         .def(py::init([] (py::array_t<double>& buf) {
             const CGAL::SimplePolygon exterior = polygon_from_numpy(buf);
             return CGAL::Polygon(exterior);}))
@@ -289,7 +289,7 @@ PYBIND11_MODULE(triangulate_dem, m) {
         .def("intersection", &intersect_polygons<CGAL::Polygon, CGAL::SimplePolygon>)
         .def("intersection", &intersect_polygons<CGAL::Polygon, CGAL::Polygon>);
 
-    py::class_<CGAL::MultiPolygon, std::unique_ptr<CGAL::MultiPolygon>>(m, "MultiPolygon")
+    py::class_<CGAL::MultiPolygon, std::unique_ptr<CGAL::MultiPolygon>>(m, "multi_polygon")
         .def(py::init(
             [] (const CGAL::Polygon& polygon) {
                 CGAL::MultiPolygon self;

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -151,7 +151,7 @@ void bind_rasterdata(py::module &m, const std::string& pyname) {
             auto buffer = data_array.request();
             int m = buffer.shape[0], n = buffer.shape[1];
 
-            return rasputin::RasterData<FT>(x_min, y_max, delta_x, delta_y, n, m, static_cast<FT*>(buffer.ptr) );
+            return rasputin::RasterData<FT>(x_min, y_max, delta_x, delta_y, m, n, static_cast<FT*>(buffer.ptr) );
         }), py::return_value_policy::take_ownership,  py::keep_alive<1, 2>(),
             py::arg("data_array").noconvert(), py::arg("x_min"), py::arg("y_max"), py::arg("delta_x"), py::arg("delta_y"))
     .def_buffer([] (rasputin::RasterData<FT>& self) {
@@ -174,7 +174,7 @@ void bind_rasterdata(py::module &m, const std::string& pyname) {
     .def_property_readonly("y_min", &rasputin::RasterData<FT>::get_y_min)
     .def("__getitem__", [](rasputin::RasterData<FT>& self, std::pair<int, int> idx) {
                 auto [i, j] = idx;
-                return self.data[self.num_points_x * i + j]; })
+                return self.data[self.num_points_y * i + j]; })
     .def("get_indices", &rasputin::RasterData<FT>::get_indices)
     .def("exterior", &rasputin::RasterData<FT>::exterior, py::return_value_policy::take_ownership)
     .def("contains", &rasputin::RasterData<FT>::contains)

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -344,6 +344,7 @@ PYBIND11_MODULE(triangulate_dem, m) {
             }, py::return_value_policy::take_ownership,
             "Simplify the mesh.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.")
         .def("copy", &rasputin::Mesh::copy, py::return_value_policy::take_ownership)
+        .def("extract_sub_mesh", &rasputin::Mesh::extract_sub_mesh, py::return_value_policy::take_ownership)
 
         .def_property_readonly("num_vertices", &rasputin::Mesh::num_vertices)
         .def_property_readonly("num_edges", &rasputin::Mesh::num_edges)
@@ -354,6 +355,12 @@ PYBIND11_MODULE(triangulate_dem, m) {
 
     m.def("compute_shadow", &rasputin::compute_shadow, "Compute shadows for given sun ray direction.")
      .def("compute_shadows", &rasputin::compute_shadows, "Compute shadows for a series of times and ray directions.")
+     .def("construct_mesh",
+            [] (const rasputin::point3_vector& points, const rasputin::face_vector & faces) {
+                rasputin::VertexIndexMap index_map;
+                rasputin::FaceDescrMap face_map;
+                return rasputin::Mesh(rasputin::construct_mesh(points, faces, index_map, face_map));
+         }, py::return_value_policy::take_ownership)
      .def("surface_normals", &rasputin::surface_normals,
           "Compute surface normals for all faces in the mesh.",
           py::return_value_policy::take_ownership)

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -219,6 +219,18 @@ void bind_tin_from_raster(py::module &m) {
             "Construct a TIN based on the points provided.\n\nThe LindstromTurk cost and placement strategy is used, and simplification process stops when the number of undirected edges drops below the ratio threshold.");
 }
 
+template<typename R, typename P>
+void bind_make_mesh(py::module &m) {
+        m.def("make_mesh",
+            [] (const R& raster_data, const P polygon) {
+                return rasputin::mesh_from_raster(raster_data, polygon);
+            })
+        .def("make_mesh",
+            [] (const R& raster_data) {
+                return rasputin::mesh_from_raster(raster_data);
+            });
+}
+
 PYBIND11_MODULE(triangulate_dem, m) {
     py::bind_vector<rasputin::point3_vector>(m, "point3_vector", py::buffer_protocol())
       .def_buffer(&vecarray_buffer<double, 3>)
@@ -319,6 +331,11 @@ PYBIND11_MODULE(triangulate_dem, m) {
     bind_tin_from_raster<rasputin::RasterData<double>>(m);
     bind_tin_from_raster<rasputin::RasterData<float>, CGAL::SimplePolygon>(m);
 
+    bind_make_mesh<std::vector<rasputin::RasterData<float>>, CGAL::SimplePolygon>(m);
+    bind_make_mesh<std::vector<rasputin::RasterData<double>>, CGAL::SimplePolygon>(m);
+    bind_make_mesh<rasputin::RasterData<float>, CGAL::SimplePolygon>(m);
+    bind_make_mesh<rasputin::RasterData<double>, CGAL::SimplePolygon>(m);
+
     // Polygons with hole not yet supported
     // bind_tin_from_raster<rasputin::RasterData<float>, CGAL::Polygon>(m);
     bind_tin_from_raster<rasputin::RasterData<double>, CGAL::SimplePolygon>(m);
@@ -349,16 +366,6 @@ PYBIND11_MODULE(triangulate_dem, m) {
 
         .def_property_readonly("points", &rasputin::Mesh::get_points, py::return_value_policy::reference_internal)
         .def_property_readonly("faces", &rasputin::Mesh::get_faces, py::return_value_policy::reference_internal);
-
-        /* m.def("make_mesh", &rasputin::mesh_from_raster<std::vector<rasputin::RasterData<float>>>); */
-        /* m.def("make_mesh", */
-        /*     [] (rasputin::RasterData<float> raster_data, CGAL::SimplePolygon polygon) { */
-        /*         return rasputin::mesh_from_raster(raster_data, polygon); */
-        /*     }) */
-        m.def("make_mesh",
-            [] (std::vector<rasputin::RasterData<float>> raster_data, CGAL::SimplePolygon polygon) {
-                return rasputin::mesh_from_raster(raster_data, polygon);
-            });
 
     py::class_<std::vector<rasputin::RasterData<float>>, std::unique_ptr<std::vector<rasputin::RasterData<float>>>> (m, "raster_list")
         .def(py::init( [] () {std::vector<rasputin::RasterData<float>> self; return self;}))

--- a/src/rasputin/bindings.cpp
+++ b/src/rasputin/bindings.cpp
@@ -236,8 +236,16 @@ PYBIND11_MODULE(triangulate_dem, m) {
 
     bind_make_mesh<std::vector<rasputin::RasterData<float>>, CGAL::SimplePolygon>(m);
     bind_make_mesh<std::vector<rasputin::RasterData<double>>, CGAL::SimplePolygon>(m);
+    bind_make_mesh<std::vector<rasputin::RasterData<float>>, CGAL::Polygon>(m);
+    bind_make_mesh<std::vector<rasputin::RasterData<double>>, CGAL::Polygon>(m);
+    // bind_make_mesh<std::vector<rasputin::RasterData<float>>, CGAL::MultiPolygon>(m);
+    // bind_make_mesh<std::vector<rasputin::RasterData<double>>, CGAL::MultiPolygon>(m);
     bind_make_mesh<rasputin::RasterData<float>, CGAL::SimplePolygon>(m);
     bind_make_mesh<rasputin::RasterData<double>, CGAL::SimplePolygon>(m);
+    bind_make_mesh<rasputin::RasterData<float>, CGAL::Polygon>(m);
+    bind_make_mesh<rasputin::RasterData<double>, CGAL::Polygon>(m);
+    // bind_make_mesh<rasputin::RasterData<float>, CGAL::MultiPolygon>(m);
+    // bind_make_mesh<rasputin::RasterData<double>, CGAL::MultiPolygon>(m);
 
     py::class_<CGAL::SimplePolygon, std::unique_ptr<CGAL::SimplePolygon>>(m, "simple_polygon")
         .def(py::init(&polygon_from_numpy))
@@ -271,6 +279,8 @@ PYBIND11_MODULE(triangulate_dem, m) {
                         result.append(*h);
                     return result;
                     })
+        .def("extract_boundaries", [] (const CGAL::Polygon& self) {return CGAL::extract_boundaries(self);},
+                py::return_value_policy::take_ownership)
         .def("exterior", [] (const CGAL::Polygon& self) {return self.outer_boundary();})
         .def("join", &join_polygons<CGAL::Polygon, CGAL::SimplePolygon>)
         .def("join", &join_polygons<CGAL::Polygon, CGAL::Polygon>)
@@ -300,6 +310,8 @@ PYBIND11_MODULE(triangulate_dem, m) {
                     result.append(*p);
                 return result;
             })
+        .def("extract_boundaries", [] (const CGAL::MultiPolygon& self) {return CGAL::extract_boundaries(self);},
+                py::return_value_policy::take_ownership)
         .def("join",
             [] (const CGAL::MultiPolygon a, CGAL::SimplePolygon b) {
                 return join_multipolygons(a, CGAL::MultiPolygon({static_cast<CGAL::Polygon>(b)}));

--- a/src/rasputin/geo_tiff_reader.py
+++ b/src/rasputin/geo_tiff_reader.py
@@ -9,8 +9,6 @@ from rasputin.writer import write
 from rasputin.reader import read_raster_file
 from rasputin.geometry import GeoPolygon
 from rasputin.calculate import compute_shade
-from rasputin.triangulate_dem import lindstrom_turk_by_ratio
-from rasputin.triangulate_dem import lindstrom_turk_by_size
 from rasputin.triangulate_dem import orient_tin, compute_slopes
 
 
@@ -54,26 +52,14 @@ def geo_tiff_reader():
     logger.debug(f"Original: {m * n}")
     logger.critical(rasterdata.info)
 
-    geo_polygon = GeoPolygon(polygon=polygon, proj=None)
+    domain = GeoPolygon(polygon=polygon, proj=None)
 
-    if res.ratio:
-        if polygon:
-            pts, faces = lindstrom_turk_by_ratio(rasterdata._cpp,
-                                                 geo_polygon._cpp,
-                                                 res.ratio)
-        else:
-            pts, faces = lindstrom_turk_by_ratio(rasterdata._cpp, res.ratio)
-    else:
-        if polygon:
-            pts, faces = lindstrom_turk_by_size(rasterdata._cpp,
-                                                geo_polygon._cpp,
-                                                res.size)
-        else:
-            pts, faces = lindstrom_turk_by_size(rasterdata._cpp, res.size)
+    mesh = (Mesh.from_raster(rasterda=rasterdata, domain=domain)
+            .simplify(ratio=res.ratio, max_size=res.max_size))
+
+    pts, faces, normals = mesh.points, mesh.faces, mesh.face_normals
+
     logger.debug(f"Result: {len(pts)}")
-
-    # Compute normals and re-orient before shadow computation
-    normals = orient_tin(pts, faces)
 
     # Compute additional fields
     fields = {}

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -195,8 +195,7 @@ class GeoPolygon:
     def buffer(self, value: float) -> "GeoPolygon":
         return GeoPolygon(polygon=self.polygon.buffer(value), projection=self.projection)
 
-    @property
-    def to_cpp(self) -> td.simple_polygon:
+    def to_cpp(self) -> Union[td.simple_polygon, td.polygon]:
         # Note: Shapely polygons have one vertex repeated and orientation dos not matter
         #       CGAL polygons have no vertex repeated and orientation mattters
         from shapely.geometry.polygon import orient
@@ -208,4 +207,7 @@ class GeoPolygon:
         cgal_polygon = td.simple_polygon(exterior)
         for interior in interiors:
             cgal_polygon = cgal_polygon.difference(interior)
+            # Intersection result is MultiPolygon
+            if cgal_polygon.num_parts() == 1:
+                cgal_polygon = cgal_polygon[0]
         return cgal_polygon

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -165,13 +165,13 @@ class GeoPolygon:
 
     @classmethod
     def from_raster_file(cls, *, filepath: Path) -> "GeoPolygon":
-        from rasputin.reader import identify_projection, get_image_bounds
+        from rasputin.reader import identify_projection, get_image_extents
         from PIL import Image
         with Image.open(filepath) as image:
             projection_str = identify_projection(image=image)
-            image_bounds = get_image_bounds(image=image)
+            image_extents = get_image_extents(image=image)
 
-        return GeoPolygon(polygon=geometry.Polygon.from_bounds(*image_bounds),
+        return GeoPolygon(polygon=geometry.Polygon.from_bounds(*image_extents.box),
                           projection=pyproj.Proj(projection_str))
 
     @classmethod

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -200,13 +200,14 @@ class GeoPolygon:
         #       CGAL polygons have no vertex repeated and orientation mattters
         from shapely.geometry.polygon import orient
 
+        # Get point sequences as arrays
         exterior = np.asarray(orient(self.polygon).exterior)[:-1]
         interiors = [np.asarray(hole)[:-1]
                     for hole in orient(self.polygon,-1).interiors]
 
         cgal_polygon = td.simple_polygon(exterior)
         for interior in interiors:
-            cgal_polygon = cgal_polygon.difference(interior)
+            cgal_polygon = cgal_polygon.difference(td.simple_polygon(interior))
             # Intersection result is MultiPolygon
             if cgal_polygon.num_parts() == 1:
                 cgal_polygon = cgal_polygon[0]

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -2,7 +2,7 @@ from typing import Tuple, List, Optional, Union
 import io
 import shutil
 from functools import partial
-from shapely import ops
+from shapely import ops, wkt
 from pathlib import Path
 from dataclasses import dataclass
 from pyproj import Proj
@@ -173,6 +173,19 @@ class GeoPolygon:
 
         return GeoPolygon(polygon=geometry.Polygon.from_bounds(*image_bounds),
                           projection=pyproj.Proj(projection_str))
+
+    @classmethod
+    def from_polygon_file(cls, *, filepath: Path, projection: pyproj.Proj) -> "GeoPolygon":
+        if filepath.suffix.lower() == ".wkb":
+            with filepath.open("rb") as pfile:
+                polygon = wkb.loads(pfile.read())
+        elif filepath.suffix.lower() == ".wkt":
+            with filepath.open("r") as pfile:
+                polygon = wkt.loads(pfile.read())
+        else:
+            raise ValueError("Cannot determine file type.")
+
+        return GeoPolygon(polygon=polygon, projection=projection)
 
     def transform(self, *, target_projection: pyproj.Proj) -> "GeoPolygon":
         if target_projection.definition_string() != self.projection.definition_string():

--- a/src/rasputin/geometry.py
+++ b/src/rasputin/geometry.py
@@ -209,5 +209,3 @@ class GeoPolygon:
         for interior in interiors:
             cgal_polygon = cgal_polygon.difference(interior)
         return cgal_polygon
-
-

--- a/src/rasputin/mesh.py
+++ b/src/rasputin/mesh.py
@@ -21,13 +21,13 @@ class Mesh(object):
                 rasterdata_cpp = triangulate_dem.raster_list_float()
 
             for raster in data:
-                rasterdata_cpp.add_raster(raster._cpp)
+                rasterdata_cpp.add_raster(raster.to_cpp())
 
         else:
-            rasterdata_cpp = data._cpp
+            rasterdata_cpp = data.to_cpp()
 
         if domain:
-            mesh = cls(triangulate_dem.make_mesh(rasterdata_cpp, domain._cpp))
+            mesh = cls(triangulate_dem.make_mesh(rasterdata_cpp, domain.to_cpp()))
         else:
             mesh = cls(triangulate_dem.make_mesh(rasterdata_cpp))
 

--- a/src/rasputin/mesh.py
+++ b/src/rasputin/mesh.py
@@ -124,8 +124,8 @@ class Mesh:
     def copy(self) -> "Mesh":
         return self.__class__(self._cpp.copy())
 
-    def extract_sub_mesh(self, faces: np.ndarray) -> "Mesh":
-        return self.__class__(self._cpp.extract_sub_mesh(faces))
+    def extract_sub_mesh(self, faces: np.ndarray):
+        return self.__class__(self._cpp.extract_sub_mesh(faces));
 
     def write(self, filename: str):
         """

--- a/src/rasputin/mesh.py
+++ b/src/rasputin/mesh.py
@@ -12,7 +12,7 @@ class Mesh(object):
     @classmethod
     def from_raster(cls,
                     data: tp.Union[tp.List[Rasterdata], Rasterdata],
-                    domain: GeoPolygon) -> "Mesh":
+                    domain: tp.Optional[GeoPolygon] = None) -> "Mesh":
         # Extract cpp objects
         if isinstance(data, list):
             if data[0].array.dtype == np.float64:

--- a/src/rasputin/mesh.py
+++ b/src/rasputin/mesh.py
@@ -3,6 +3,7 @@ import typing as tp
 
 from . import triangulate_dem
 from .reader import GeoPolygon, Rasterdata
+import meshio
 
 class Mesh(object):
     def __init__(self, cpp_mesh: triangulate_dem.Mesh):

--- a/src/rasputin/mesh.py
+++ b/src/rasputin/mesh.py
@@ -1,0 +1,86 @@
+import numpy as np
+import typing as tp
+
+import shapely as sl
+from . import triangulate_dem
+
+class Mesh(object):
+    def __init__(self, cpp_mesh: triangulate_dem.Mesh):
+        self._cpp = cpp_mesh
+
+    @property
+    def num_points(self) -> int:
+        return self._cpp.num_vertices
+
+    @property
+    def num_edges(self) -> int:
+        return self._cpp.num_edges
+
+    @property
+    def num_faces(self) -> int:
+        return self._cpp.num_faces
+
+    @property
+    def characteristic(self) -> int:
+        return self.num_points - self.num_edges + self.num_faces
+
+    @property
+    def points(self) -> triangulate_dem.point3_vector:
+        array = np.asarray(self._cpp.points)
+        array.flags.writeable = False
+        return array
+
+    @property
+    def faces(self) -> triangulate_dem.face_vector:
+        array = np.asarray(self._cpp.faces)
+        array.flags.writeable = False
+        return array
+
+    @property
+    def face_normals(self) -> triangulate_dem.point3_vector:
+        # Only compute normals when needed, and only once
+        if not hasattr(self, "_face_normals"):
+            self._face_normals = triangulate_dem.surface_normals(self._cpp.points,
+                                                                 self._cpp.faces)
+
+        array = np.asarray(self._face_normals)
+        array.flags.writeable = False
+        return array
+
+    def coarsen(self,
+                *,
+                ratio: tp.Optional[float] = None,
+                max_size: tp.Optional[int] = None) -> "Mesh":
+
+        """
+        Simplify mesh by edge collapse, using the Lindstrom-Turk cost functional
+        for minimising the deformations.
+
+        :ratio:    Target ratio for edges in result mesh to edges in initial mesh
+        :max_size: Maximum number of edges in the result mesh
+        :returns:  Mesh
+
+        """
+        result = self
+        if ratio is not None:
+            result = self.__class__(self._cpp.lindstrom_turk_by_ratio(ratio))
+
+        if max_size is not None:
+            result = self.__class__(self._cpp.lindstrom_turk_by_size(max_size))
+
+        # If no valid criteria return a copy (consistent with e.g. ratio > 1)
+        if ratio is None and max_size is None:
+            result = self.copy()
+
+        return result
+
+    def copy(self) -> "Mesh":
+        return self.__class__(self._cpp.copy())
+
+    def write(self, filename: str):
+        """
+        Write mesh to file using meshio.
+        """
+        meshio.write_points_cells(filename,
+                                  self.points,
+                                  dict(triangle=self.faces))

--- a/src/rasputin/py2js.py
+++ b/src/rasputin/py2js.py
@@ -1,11 +1,10 @@
-from typing import Generator, Optional, Union
+from typing import Generator, Optional
 import numpy as np
-from rasputin import triangulate_dem as td
 
 
 def face_vector_to_lines(*,
                          name: str,
-                         face_vector: td.face_vector)-> Generator[str, None, None]:
+                         face_vector: np.ndarray)-> Generator[str, None, None]:
     yield f'const {name} = ['
     for v in face_vector:
         yield f"    {', '.join([str(s) for s in v])},"
@@ -14,7 +13,7 @@ def face_vector_to_lines(*,
 
 def point_vector_to_lines(*,
                           name: Optional[str],
-                          point_vector: Union[np.ndarray, td.point3_vector])-> Generator[str, None, None]:
+                          point_vector: np.ndarray)-> Generator[str, None, None]:
     if name is not None:
         yield f'const {name} = new Float32Array( ['
     else:
@@ -29,8 +28,8 @@ def point_vector_to_lines(*,
 
 def face_and_point_vector_to_lines(*,
                                    name: Optional[str],
-                                   face_vector: td.face_vector,
-                                   point_vector: td.point3_vector) -> Generator[str, None, None]:
+                                   face_vector: np.ndarray,
+                                   point_vector: np.ndarray) -> Generator[str, None, None]:
     if name is not None:
         yield f'const {name} = new Float32Array( ['
     else:

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -315,11 +315,11 @@ class Rasterdata:
 
     @property
     def x_max(self):
-        return self.x_min + (self.array.shape[1] - 1) * self.delta_x
+        return self.x_min + (self.array.shape[0] - 1) * self.delta_x
 
     @property
     def y_min(self):
-        return self.y_max - (self.array.shape[0] - 1) * self.delta_y
+        return self.y_max - (self.array.shape[1] - 1) * self.delta_y
 
     @property
     def box(self):
@@ -354,13 +354,13 @@ def read_raster_file(*,
         coordinate_system = identify_projection(image=image)
 
         delta_x, delta_y, _ = model_pixel_scale
-        j_tag, i_tag, _, x_tag, y_tag, _ = model_tie_point
+        i_tag, j_tag, _, x_tag, y_tag, _ = model_tie_point
 
-        x_min = x_tag - delta_x * j_tag
-        y_max = y_tag + delta_y * i_tag
+        x_min = x_tag - delta_x * i_tag
+        y_max = y_tag + delta_y * j_tag
 
-        x_max = x_tag + delta_x * (m - 1 - j_tag)
-        y_min = y_tag - delta_y * (n - 1 - i_tag)
+        x_max = x_tag + delta_x * (m - 1 - i_tag)
+        y_min = y_tag - delta_y * (n - 1 - j_tag)
 
         # If polygon is provided we crop the raster image to the polygon
         if polygon:

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -325,7 +325,6 @@ class Rasterdata:
     def box(self):
         return (self.x_min, self.y_min, self.x_max, self.y_max)
 
-    @property
     def to_cpp(self) -> triangulate_dem.raster_data_float:
         return triangulate_dem.raster_data_float(self.array,
                                                  self.x_min,

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -5,6 +5,7 @@ from PIL import Image
 from PIL.TiffImagePlugin import TiffImageFile
 from rasputin.geometry import GeoPolygon
 import re
+import pyproj
 
 import numpy as np
 from pathlib import Path
@@ -324,6 +325,11 @@ class Rasterdata:
     @property
     def box(self):
         return (self.x_min, self.y_min, self.x_max, self.y_max)
+
+    @property
+    def polygon(self):
+        return GeoPolygon(polygon=Polygon.from_bounds(*self.box),
+                          projection=pyproj.Proj(self.coordinate_system))
 
     def to_cpp(self) -> triangulate_dem.raster_data_float:
         return triangulate_dem.raster_data_float(self.array,

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -135,21 +135,6 @@ def extract_geo_keys(*, image: TiffImageFile) -> Dict[str, Any]:
 
     return geo_keys
 
-def get_image_bounds(image: TiffImageFile) -> tuple:
-    m, n = image.size
-
-    scale_idx = GeoTiffTags.ModelPixelScaleTag.value
-    delta_x, delta_y, _ = image.tag_v2.get(scale_idx, (1.0, 1.0, 0.0))
-
-    tiepoint_idx = GeoTiffTags.ModelTiePointTag.value
-    j_tag, i_tag, _, x_tag, y_tag, _ = image.tag_v2.get(tiepoint_idx, (0, 0, 0, 0, 0, 0))
-
-    x_min = x_tag - delta_x * j_tag
-    y_max = y_tag + delta_y * i_tag
-    x_max = x_tag + delta_x * (m - 1 - j_tag)
-    y_min = y_tag - delta_y * (n - 1 - i_tag)
-
-    return (x_min, y_min, x_max, y_max)
 
 class GeoKeysInterpreter(object):
     """
@@ -304,27 +289,39 @@ def identify_projection(*, image: TiffImageFile) -> str:
 
 
 @dataclass
-class Rasterdata:
-
-    array: np.ndarray
-    x_min: float
-    y_max: float
+class ImageExtents:
+    shape: Tuple[int, int]
     delta_x: float
     delta_y: float
-    coordinate_system: str
-    info: Dict[str, Any]
+    x_min: float
+    y_max: float
 
     @property
     def x_max(self):
-        return self.x_min + (self.array.shape[0] - 1) * self.delta_x
+        return self.x_min + self.delta_x * (self.shape[0] - 1)
 
     @property
     def y_min(self):
-        return self.y_max - (self.array.shape[1] - 1) * self.delta_y
+        return self.y_max - self.delta_y * (self.shape[1] - 1)
 
     @property
     def box(self):
         return (self.x_min, self.y_min, self.x_max, self.y_max)
+
+    def __post_init__(self):
+        assert len(self.shape) == 2 and min(*self.shape) > 0, "Shape is not two-dimensional."
+        assert min(self.delta_x, self.delta_y) > 0, "Step sizes must be strictly positive."
+
+@dataclass
+class Rasterdata(ImageExtents):
+    array: np.ndarray
+    coordinate_system: str
+    info: Dict[str, Any]
+
+    def __post_init__(self):
+        shapes = self.shape, self.array.shape
+        assert shapes[0] == shapes[1], f"Unexpected array shape: expected {shapes[0]} but got {shapes[1]}"
+        super().__post_init__()
 
     @property
     def polygon(self):
@@ -338,6 +335,61 @@ class Rasterdata:
                                                  self.delta_x,
                                                  self.delta_y)
 
+def crop_image_to_polygon(*,
+                          image: Image.Image,
+                          polygon: Polygon) -> Tuple[Image.Image, ImageExtents]:
+    extents = get_image_extents(image)
+
+    (m, n) = extents.shape
+    delta_x, delta_y = extents.delta_x, extents.delta_y
+
+    # Image box
+    x_min, y_min, x_max, y_max = extents.box
+
+    # Polygon bounding box
+    x_min_p, y_min_p, x_max_p, y_max_p = polygon.bounds
+
+    # We need polygon bounds in image coordinates
+    x_min_p, y_min_p, x_max_p, y_max_p = polygon.bounds
+
+    i_min = np.clip(np.floor((x_min_p - x_min)/delta_x), 0, m-1)
+    j_min = np.clip(np.floor((y_max - y_max_p)/delta_y), 0, n-1)
+    i_max = np.clip(np.ceil((x_max_p - x_min)/delta_x) + 1, 1, m)
+    j_max = np.clip(np.ceil((y_max - y_min_p)/delta_y) + 1, 1, n)
+
+    # NOTE: Issues with Pillows Image.crop
+    #     - Cropping is sepcified in image coordinates (transpose of array coordinates)
+    #     - Cropping does not include last indices of the cropping box
+    #     - Cropping discards tiff tags
+
+    sub_image = image.crop(box=(j_min, i_min, j_max, i_max))
+
+    # Find extents of the cropped image
+    sub_extents = ImageExtents(shape=(i_max - i_min, j_max - j_min),
+                               delta_x=delta_x, delta_y=delta_y,
+                               x_min=x_min + i_min * delta_x,
+                               y_max=y_max - j_min * delta_y)
+
+    return sub_image, sub_extents
+
+def get_image_extents(image: Image.Image) -> Tuple[float, float, float, float]:
+    n, m = image.size
+
+    tiepoint_idx = GeoTiffTags.ModelTiePointTag.value
+    i_tag, j_tag, _, x_tag, y_tag, _ = image.tag_v2.get(tiepoint_idx, (0, 0, 0, 0, 0, 0))
+
+    scale_idx = GeoTiffTags.ModelPixelScaleTag.value
+    delta_x, delta_y, _ = image.tag_v2.get(scale_idx, (1.0, 1.0, 0.0))
+
+    x_min = x_tag - delta_x * i_tag
+    y_max = y_tag + delta_y * j_tag
+
+    x_max = x_tag + delta_x * (m - 1 - i_tag)
+    y_min = y_tag - delta_y * (n - 1 - j_tag)
+
+    return ImageExtents(shape=(m, n),
+                        delta_x=delta_x, delta_y=delta_y,
+                        x_min=x_min, y_max=y_max)
 
 def read_raster_file(*,
                      filepath: Path,
@@ -347,59 +399,24 @@ def read_raster_file(*,
     assert filepath.exists()
 
     with Image.open(filepath) as image:
-        # Determine image extents
-        # NOTE: image coordinate tranposed relative to array: array(image).shape == m, n
-        n, m = image.size
-
-        # Use pixel coordinates if image does not define an affine transformation
-        # This should only happen if the image is not a GeoTIFF
-        model_pixel_scale = image.tag_v2.get(GeoTiffTags.ModelPixelScaleTag.value, (1.0, 1.0, 0.0))
-        model_tie_point = image.tag_v2.get(GeoTiffTags.ModelTiePointTag.value, (0, 0, 0, 0, 0, 0))
-
+        # Since cropping discards tiff tags we extract tags data first
         info = extract_geo_keys(image=image)
         coordinate_system = identify_projection(image=image)
 
-        delta_x, delta_y, _ = model_pixel_scale
-        i_tag, j_tag, _, x_tag, y_tag, _ = model_tie_point
-
-        x_min = x_tag - delta_x * i_tag
-        y_max = y_tag + delta_y * j_tag
-
-        x_max = x_tag + delta_x * (m - 1 - i_tag)
-        y_min = y_tag - delta_y * (n - 1 - j_tag)
-
-        # If polygon is provided we crop the raster image to the polygon
         if polygon:
-            # Get maximal extents of the polygon within the raster domain
-            raster_domain = (Polygon([(x_min, y_min), (x_max, y_min),
-                                      (x_max, y_max), (x_min, y_max)])
-                             # buffer to avoid potential issues from CG roundoff errors
-                             .buffer(0.1 * max(delta_x, delta_y)))
-            #polygon = polygon.intersection(raster_domain)
+            image, extents = crop_image_to_polygon(image=image, polygon=polygon)
+        else:
+            extents = get_image_extents(image)
 
-            # Find indices for the box in array coordinates
-            x_min_p, y_min_p, x_max_p, y_max_p = polygon.bounds
-            i_min = np.clip(np.floor((x_min_p - x_min)/delta_x), 0, m-1)
-            j_min = np.clip(np.floor((y_max - y_max_p)/delta_y), 0, n-1)
-            i_max = np.clip(np.ceil((x_max_p - x_min)/delta_x) + 1, 1, m)
-            j_max = np.clip(np.ceil((y_max - y_min_p)/delta_y) + 1, 1, n)
-
-            # NOTE: Cropping does not include last indices
-            # NOTE: Cropping in image coordinates (transpose of array coordinates)
-            image = image.crop(box=(j_min, i_min, j_max, i_max))
-
-            # Find extents of the cropped image
-            x_min = x_tag + (i_min - i_tag) * delta_x
-            y_max = y_tag - (j_min - j_tag) * delta_y
-
-        # NOTE: Storing the array ensures the pointer to the data stays alive
+        # Store the array to ensure the pointer to the data stays alive
         image_array = np.array(image)
 
     logger.debug("Done")
 
-    return Rasterdata(array=image_array, x_min=x_min, y_max=y_max,
-                      delta_x=delta_x, delta_y=delta_y, info=info,
-                      coordinate_system=coordinate_system)
+    return Rasterdata(array=image_array, shape=extents.shape,
+                      x_min=extents.x_min, y_max=extents.y_max,
+                      delta_x=extents.delta_x, delta_y=extents.delta_y,
+                      info=info, coordinate_system=coordinate_system)
 
 class RasterRepository:
 

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -3,7 +3,7 @@ import numpy as np
 from datetime import datetime
 from h5py import File
 from pathlib import Path
-from rasputin.triangulate_dem import point3_vector, face_vector, consolidate
+from rasputin.mesh import Mesh
 from rasputin.geometry import Geometry
 
 
@@ -37,8 +37,8 @@ class TinRepository:
                 projection = group["points"].attrs["projection"]
                 faces = group["faces"][:]
                 color = group["faces"].attrs["color"]
-                geometries[name] = Geometry(points=point3_vector(pts.tolist()),
-                                            faces=face_vector(faces.tolist()),
+                mesh = Mesh.from_points_and_faces(points=pts, faces=faces)
+                geometries[name] = Geometry(mesh=mesh,
                                             projection=projection,
                                             base_color=color,
                                             material=None)

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -316,7 +316,7 @@ CGAL::DelaunayConstraints interpolate_boundary_points(const RasterData<T>& raste
 
             // We can skip edges that are aligend with the raster boundary
             // TODO: Consider checking using CGAL and exact arithmentic
-            bool edge_is_aligned = not raster.contains((first_vertex.x() + second_vertex.x())/3,
+            bool edge_is_aligned = not raster.contains((first_vertex.x() + second_vertex.x())/2,
                                                        (first_vertex.y() + second_vertex.y())/2);
             if (edge_is_aligned) {
                 continue;

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -236,16 +236,16 @@ struct RasterData {
         CGAL::PointList points;
         points.reserve(num_points_x * num_points_y);
 
-        for (std::size_t i = 0; i < num_points_y; ++i)
-            for (std::size_t j = 0; j < num_points_x; ++j)
-                points.emplace_back(x_min + j*delta_x, y_max - i*delta_y, data[i*num_points_x + j]);
+        for (std::size_t i = 0; i < num_points_x; ++i)
+            for (std::size_t j = 0; j < num_points_y; ++j)
+                points.emplace_back(x_min + i*delta_x, y_max - j*delta_y, data[i*num_points_y + j]);
         return points;
     }
 
     // For every point inside the raster rectangle we identify indices (i, j) of the upper-left vertex of the cell containing the point
     std::pair<int, int> get_indices(double x, double y) const {
-        int j = std::min<int>(std::max<int>(static_cast<int>((x-x_min) /delta_x), 0), num_points_x - 1);
-        int i = std::min<int>(std::max<int>(static_cast<int>((y_max-y) /delta_y), 0), num_points_y - 1);
+        int i = std::min<int>(std::max<int>(static_cast<int>((x-x_min) /delta_x), 0), num_points_x - 1);
+        int j = std::min<int>(std::max<int>(static_cast<int>((y_max-y) /delta_y), 0), num_points_y - 1);
 
         return std::make_pair(i,j);
     }
@@ -256,16 +256,16 @@ struct RasterData {
         auto [i, j] = get_indices(x, y);
 
         // Determine the cell corners
-        double x_0 = x_min + j * delta_x,
-               y_0 = y_max - i * delta_y,
-               x_1 = x_min + (j+1) * delta_x,
-               y_1 = y_max - (i+1) * delta_y;
+        double x_0 = x_min + i * delta_x,
+               y_0 = y_max - j * delta_y,
+               x_1 = x_min + (i+1) * delta_x,
+               y_1 = y_max - (j+1) * delta_y;
 
         // Using bilinear interpolation on the celll
-        double h = data[(i + 0)*num_points_x + j + 0] * (x_1 - x)/delta_x * (y - y_1)/delta_y
-                 + data[(i + 1)*num_points_x + j + 0] * (x_1 - x)/delta_x * (y_0 - y)/delta_y
-                 + data[(i + 0)*num_points_x + j + 1] * (x - x_0)/delta_x * (y - y_1)/delta_y
-                 + data[(i + 1)*num_points_x + j + 1] * (x - x_0)/delta_x * (y_0 - y)/delta_y;
+        double h = data[(i + 0)*num_points_y + j + 0] * (x_1 - x)/delta_x * (y - y_1)/delta_y
+                 + data[(i + 1)*num_points_y + j + 0] * (x - x_0)/delta_x * (y - y_1)/delta_y
+                 + data[(i + 0)*num_points_y + j + 1] * (x_1 - x)/delta_x * (y_0 - y)/delta_y
+                 + data[(i + 1)*num_points_y + j + 1] * (x - x_0)/delta_x * (y_0 - y)/delta_y;
 
         return h;
     }

--- a/src/rasputin/triangulate_dem.h
+++ b/src/rasputin/triangulate_dem.h
@@ -66,7 +66,6 @@ auto point_inside_polygon = [](const Point2& x, const SimplePolygon& poly) -> bo
     return (bounded_side_2(poly.vertices_begin(), poly.vertices_end(), x, K()) != CGAL::ON_UNBOUNDED_SIDE);
 };
 
-
 }
 
 namespace rasputin {
@@ -252,7 +251,7 @@ struct RasterData {
 
     // Determine if a point (x, y) is is strictly inside the raster domain
     bool contains(double x, double y) const {
-        bool eps = pow(pow(delta_x, 2) + pow(delta_y, 2), 0.5) * 1e-10;
+        double eps = pow(pow(delta_x, 2) + pow(delta_y, 2), 0.5) * 1e-10;
         return ((x > x_min + eps) and (x < get_x_max() - eps)
                 and (y > get_y_min() + eps) and (y < y_max - eps));
     }
@@ -267,21 +266,22 @@ CGAL::DelaunayConstraints interpolate_boundary_points(const RasterData<T>& raste
     // Iterate over edges of the intersection polygon and interpolate points
     // TODO: Handle holes. Only needed if the intersecting polygon has holes.
     CGAL::DelaunayConstraints interpolated_points;
-    for (const auto& part : intersection_polygon)
-        for (auto e = part.outer_boundary().edges_begin(); e != part.outer_boundary().edges_end(); ++e) {
+    for (const auto& part : CGAL::extract_boundaries(intersection_polygon)) {
+        for (auto e = part.edges_begin(); e != part.edges_end(); ++e) {
             CGAL::Point2 first_vertex = e->vertex(0);
             CGAL::Point2 second_vertex = e->vertex(1);
 
             // We can skip edges that are aligend with the raster boundary
             // TODO: Consider checking using CGAL and exact arithmentic
-            bool edge_is_aligned = not raster.contains((first_vertex.x() + second_vertex.x())/2,
+            bool edge_is_aligned = not raster.contains((first_vertex.x() + second_vertex.x())/3,
                                                        (first_vertex.y() + second_vertex.y())/2);
-            if (edge_is_aligned)
+            if (edge_is_aligned) {
                 continue;
+            }
 
             // Sample with the approximately the same resolution as the raster data along the boundary edges
-            double edge_len_x = second_vertex[0] - first_vertex[0];
-            double edge_len_y = second_vertex[1] - first_vertex[1];
+            double edge_len_x = second_vertex.x() - first_vertex.x();
+            double edge_len_y = second_vertex.y() - first_vertex.y();
             std::size_t num_subedges = static_cast<int>(std::max<double>(std::fabs(edge_len_x/raster.delta_x),
                                                                          std::fabs(edge_len_y/raster.delta_y)));
             num_subedges = std::max<int>(1, num_subedges);
@@ -292,13 +292,14 @@ CGAL::DelaunayConstraints interpolate_boundary_points(const RasterData<T>& raste
             // Iterate over edge samples
             std::vector<CGAL::Point> interpolated_points_on_edge;
             for (std::size_t k=0; k < num_subedges + 1; ++k) {
-                double x = first_vertex[0] + k * edge_dx;
-                double y = first_vertex[1] + k * edge_dy;
+                double x = first_vertex.x() + k * edge_dx;
+                double y = first_vertex.y() + k * edge_dy;
                 double z = raster.get_interpolated_value_at_point(x, y);
                 interpolated_points_on_edge.emplace_back(x, y, z);
             }
             interpolated_points.push_back(std::move(interpolated_points_on_edge));
         }
+    }
     return interpolated_points;
 }
 
@@ -315,42 +316,30 @@ Mesh make_mesh(const CGAL::PointList &pts,
     for (auto point_sequence: constraints)
         dtin.insert_constraint(point_sequence.begin(), point_sequence.end(), false);
 
-    CGAL::PointVertexMap pvm;
     CGAL::Mesh mesh;
+    CGAL::PointVertexMap pvm;
 
-    // Option 1: Add points that are not outside the polygon.
-    //           Add faces if all three vertices are in the mesh
-    //
-    // Option 2: Add all points
-    //           Add faces if midpoint is inside polygon
-    //           Remove hanging points
-    //
-    // Option3: Add points that not outside polygon
-    //          Add faces if midpoint is inside polygon
-    //
-    // All options are equivalent in terms of output with exact predicates and
-    // if the mesh does not contain degenerate triangles.
-
-
-    for (auto v = dtin.finite_vertices_begin(); v != dtin.finite_vertices_end(); ++v) {
-        CGAL::Point2 pt(v->point().x(), v->point().y());
-        if (not inclusion_polygon.has_on_unbounded_side(pt))
-            pvm.emplace(std::make_pair(v->point(), mesh.add_vertex(v->point())));
-    }
+    auto index = [&pvm, &mesh] (CGAL::Point v) -> CGAL::VertexIndex {
+        // Find index of point in mesh, adding it if needed
+        auto iter = pvm.find(v);
+        if (iter == pvm.end())
+            iter = pvm.emplace(std::make_pair(v, mesh.add_vertex(v))).first;
+        return iter->second;
+    };
 
     for (auto f = dtin.finite_faces_begin(); f != dtin.finite_faces_end(); ++f) {
         CGAL::Point u = f->vertex(0)->point();
         CGAL::Point v = f->vertex(1)->point();
         CGAL::Point w = f->vertex(2)->point();
 
-        // At this point we have to determine if the simplex (u, v, w) is inside polygon.
+        // Add face if midpoint is contained
         CGAL::Point2 face_midpoint(u.x()/3 + v.x()/3 + w.x()/3,
                                    u.y()/3 + v.y()/3 + w.y()/3);
-        if (inclusion_polygon.has_on_bounded_side(face_midpoint))
-            mesh.add_face(pvm[u], pvm[v], pvm[w]);
+        if (inclusion_polygon.has_on_bounded_side(face_midpoint)) {
+            mesh.add_face(index(u), index(v), index(w));
+        }
     }
     pvm.clear();
-
     return Mesh(mesh);
 };
 

--- a/src/rasputin/web_visualize.py
+++ b/src/rasputin/web_visualize.py
@@ -8,14 +8,15 @@ import argparse
 from rasputin.tin_repository import TinRepository
 from rasputin import triangulate_dem
 from rasputin.reader import RasterRepository
-from rasputin.triangulate_dem import lindstrom_turk_by_ratio
 from rasputin.geometry import Geometry, write_scene
 from rasputin.material import avalanche_material, lake_material, terrain_material
 from rasputin import avalanche
 from rasputin.avalanche import varsom_angles
 
 
-def web_visualize():
+def depr_web_visualize():
+    return
+
     """
     Avalance Forecast Visualization Example.
 

--- a/tests/test_land_cover_repository.py
+++ b/tests/test_land_cover_repository.py
@@ -51,14 +51,15 @@ def test_construct_triangulation_with_land_types():
                         projection=input_coordinate_system).transform(target_projection=target_coordinate_system)
 
     rasterdata_list = dem_repo.read(domain=domain)
-    mesh = Mesh.from_raster(rasterdata_list, domain=domain)
+    mesh = Mesh.from_raster(data=rasterdata_list, domain=domain)
 
     assert len(mesh.faces) > 0
     assert len(mesh.points) > 0
 
     centers = mesh.points[mesh.faces].mean(axis=1)
     land_types = lt_repo.land_cover(land_types=None,
-                                    geo_points=GeoPoints(xy=centers[:,:2],
+                                    geo_points=GeoPoints(xy=centers[:, :2],
                                                          projection=target_coordinate_system),
                                     domain=domain)
+    assert 0 not in land_types
     assert len(land_types) == len(mesh.faces)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -6,7 +6,8 @@ from numpy.linalg import norm
 from pyproj import Proj
 from shapely.geometry import Polygon, Point
 
-from rasputin.reader import GeoPolygon, Rasterdata
+from rasputin.geometry import GeoPolygon
+from rasputin.reader import Rasterdata
 from rasputin.mesh import Mesh
 
 
@@ -84,7 +85,7 @@ def polygon_w_hole():
                       projection=Proj(cs))
 
 def test_mesh(raster, polygon):
-    mesh = Mesh.from_raster(raster, polygon)
+    mesh = Mesh.from_raster(data=raster, domain=polygon)
 
     # Check mesh consistency
     assert len(mesh.points) == mesh.num_points
@@ -115,8 +116,13 @@ def test_mesh(raster, polygon):
     assert raster.array.max() >= z.max()
 
 
+def test_mesh_sub_mesh(raster, polygon):
+    mesh = Mesh.from_raster(data=raster, domain=polygon)
+    sub_mesh = mesh.extract_sub_mesh(array([0, 1]))
+    assert len(sub_mesh.faces) == 2
+
 def test_mesh_w_hole(raster, polygon_w_hole):
-    mesh = Mesh.from_raster(raster, polygon_w_hole)
+    mesh = Mesh.from_raster(data=raster, domain=polygon_w_hole)
 
     # Check mesh consistency
     assert len(mesh.points) == mesh.num_points
@@ -124,7 +130,7 @@ def test_mesh_w_hole(raster, polygon_w_hole):
     assert mesh.characteristic == 0
 
     # Check that all points in mesh are inside the polygon
-    test_poly = polygon_w_hole.polygon.buffer(1e-10) # Account for fixed float precision
+    test_poly = polygon_w_hole.polygon.buffer(1e-10)  # Account for fixed float precision
     for (x, y, _) in mesh.points:
         assert test_poly.contains(Point(x, y))
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,148 @@
+import pytest
+from numpy import array, cos, sin, linspace, pi, float32, zeros, ndindex
+from numpy.random import rand, randn
+from numpy.linalg import norm
+
+from pyproj import Proj
+from shapely.geometry import Polygon, Point
+
+from rasputin.reader import GeoPolygon, Rasterdata
+from rasputin.mesh import Mesh
+
+
+@pytest.fixture
+def raster():
+    m, n = 53, 10
+    array = (zeros((m,n))
+             + linspace(0, 1, m).reshape(-1,1)**2
+             + linspace(0, 1, n).reshape(1,-1))
+    return Rasterdata(array=array.astype(float32),
+                      x_min=0,
+                      y_max=1,
+                      delta_x=1 / (m-1),
+                      delta_y=1 / (n-1),
+                      coordinate_system="+init=epsg:32633",
+                      info={})
+
+@pytest.fixture
+def raster_list():
+    m0, n0, m1, n1 = 31, 20, 53, 10
+    d0, d1 = 0.57, 0.48
+    array0 = (zeros((m0,n0))
+              + linspace(0, d0, m0).reshape(-1,1)**2
+              + linspace(0, 1, n0).reshape(1,-1))
+
+    array1 = (zeros((m1,n1))
+              + linspace(d1, 1, m1).reshape(-1,1)**2
+              + linspace(0, 1, n1).reshape(1,-1))
+    return [Rasterdata(array=array0.astype(float32),
+                       x_min=0,
+                       y_max=1,
+                       delta_x=d0 / (m0-1),
+                       delta_y=1 / (n0-1),
+                       coordinate_system="+init=epsg:32633",
+                       info={}),
+            Rasterdata(array=array1.astype(float32),
+                       x_min=d1,
+                       y_max=1,
+                       delta_x=(1-d1) / (m1-1),
+                       delta_y=1 / (n1-1),
+                       coordinate_system="+init=epsg:32633",
+                       info={})]
+
+@pytest.fixture
+def polygon():
+    # Create polygonal approximation to a circle
+    N = 117
+    x, y = array([0.51, 0.5])
+    r = 0.4
+
+    cs = "+init=epsg:32633"
+
+    polygon = Polygon([(x + r*cos(t), y + r*sin(t))
+                      for t in linspace(0, 2*pi, N+1)[:-1]])
+
+    return GeoPolygon(polygon=polygon,
+                      projection=Proj(cs))
+
+@pytest.fixture
+def polygon_w_hole():
+    # Create polygonal approximation to a circle
+    N1, N2 = 117, 77
+    x, y = array([0.51, 0.5])
+    r1, r2 = 0.4, 0.25
+
+    cs = "+init=epsg:32633"
+
+    polygon_1 = Polygon((x + r1*cos(t), y + r1*sin(t))
+                        for t in linspace(0, 2*pi, N1+1)[:-1])
+
+    polygon_2 = Polygon((x + r2*cos(t), y + r2*sin(t))
+                        for t in linspace(0, 2*pi, N2+1)[:-1])
+
+    return GeoPolygon(polygon=polygon_1.difference(polygon_2),
+                      projection=Proj(cs))
+
+def test_mesh(raster, polygon):
+    mesh = Mesh.from_raster(raster, polygon)
+
+    # Check mesh consistency
+    assert len(mesh.points) == mesh.num_points
+    assert len(mesh.faces) == mesh.num_faces
+    assert mesh.characteristic == 1
+
+    # Check that all points in mesh are inside the polygon
+    test_poly = polygon.polygon.buffer(1e-10) # Account for fixed float precision
+    for (x, y, _) in mesh.points:
+        assert test_poly.contains(Point(x, y))
+
+    # Check that all points in raster not inside polygon are not mesh
+    def dist(mesh, pt):
+        return  norm(mesh.points[:,:2] - pt, axis=0).min()
+
+    for i, j in ndindex(raster.array.shape):
+        x = raster.x_min + i * raster.delta_x
+        y = raster.y_max - j * raster.delta_y
+        assert test_poly.contains(Point(x, y)) or dist(mesh, (x,y)) > 1e-10
+
+    # Some sanity tests
+    x, y, z = mesh.points.T
+    assert raster.x_min <= x.min()
+    assert raster.x_max >= x.max()
+    assert raster.y_min <= y.min()
+    assert raster.y_max >= y.max()
+    assert raster.array.min() <= z.min()
+    assert raster.array.max() >= z.max()
+
+
+def test_mesh_w_hole(raster, polygon_w_hole):
+    mesh = Mesh.from_raster(raster, polygon_w_hole)
+
+    # Check mesh consistency
+    assert len(mesh.points) == mesh.num_points
+    assert len(mesh.faces) == mesh.num_faces
+    assert mesh.characteristic == 0
+
+    # Check that all points in mesh are inside the polygon
+    test_poly = polygon_w_hole.polygon.buffer(1e-10) # Account for fixed float precision
+    for (x, y, _) in mesh.points:
+        assert test_poly.contains(Point(x, y))
+
+    # Check that all points in raster not inside polygon are not mesh
+    def dist(mesh, pt):
+        return  norm(mesh.points[:,:2] -pt, axis=0).min()
+
+    for i, j in ndindex(raster.array.shape):
+        x = raster.x_min + i * raster.delta_x
+        y = raster.y_max - j * raster.delta_y
+        assert test_poly.contains(Point(x, y)) or dist(mesh, (x,y)) > 1e-10
+
+    # Some sanity tests
+    x, y, z = mesh.points.T
+    assert raster.x_min <= x.min()
+    assert raster.x_max >= x.max()
+    assert raster.y_min <= y.min()
+    assert raster.y_max >= y.max()
+    assert raster.array.min() <= z.min()
+    assert raster.array.max() >= z.max()
+

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -1,0 +1,27 @@
+from numpy import array, cos, sin, linspace, pi
+import pytest
+
+import rasputin.triangulate_dem as td
+
+@pytest.fixture
+def rectangle_polygon():
+    return td.simple_polygon([[0.48, 0.0],
+                              [1.0, 0.0],
+                              [1.0, 1.0],
+                              [0.48, 1.0]])
+
+
+@pytest.fixture
+def circle_polygon():
+    N = 117
+    x, y = array([0.5, 0.5])
+    r = 0.4
+
+    return td.simple_polygon([(x + r*cos(t), y + r*sin(t))
+                              for t in linspace(0, 2*pi, N+1)[:-1]])
+
+
+@pytest.mark.skip # Segfaults
+def test_intersection(rectangle_polygon, circle_polygon):
+    polygon = rectangle_polygon.intersection(circle_polygon)
+    assert polygon.num_parts() == 1

--- a/tests/test_raster_repository.py
+++ b/tests/test_raster_repository.py
@@ -13,8 +13,8 @@ data_dir = os.environ["RASPUTIN_DATA_DIR"]
 def test_get():
     x0 = 8.54758671814368
     y0 = 60.898468
-    repo = RasterRepository(directory=Path(data_dir))
-    input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
+    repo = RasterRepository(directory=Path(data_dir) / "dem_archive")
+    input_coordinate_system = pyproj.Proj(init="EPSG:4326")
     #target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
     polygon = Polygon.from_bounds(xmin=x0 - 0.1, xmax=x0 + 0.1, ymin=y0 - 0.1, ymax=y0 + 0.1)
     geo_polygon = GeoPolygon(projection=input_coordinate_system, polygon=polygon)

--- a/tests/test_read_raster_file.py
+++ b/tests/test_read_raster_file.py
@@ -1,0 +1,93 @@
+import pytest
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+from PIL import Image, TiffImagePlugin
+from shapely.geometry import Polygon
+
+from rasputin.reader import read_raster_file, crop_image_to_polygon, get_image_extents
+from rasputin.reader import GeoTiffTags
+
+@contextmanager
+def image_from_array(array: np.ndarray):
+    # Provides a tiff image file interface to a numpy array
+    image = Image.fromarray(array)
+    m, n = array.shape
+
+    # Store image extent data in tiff tags
+    tags = TiffImagePlugin.ImageFileDirectory_v2()
+    scale_tag = GeoTiffTags.ModelPixelScaleTag.value
+    tiept_tag = GeoTiffTags.ModelTiePointTag.value
+
+    tags[scale_tag] = (1, 1, 0)
+    tags[tiept_tag] = (0, 0, 0, 0, n-1, 0)
+
+    # Store to temporary file
+    _, temp_name = tempfile.mkstemp(suffix=".tif")
+    temp_path = Path(temp_name)
+    try:
+        fp = temp_path.open(mode="w+b")
+        image.save(fp, format="tiff", tiffinfo=tags)
+
+        yield Image.open(fp)
+
+        fp.close()
+    finally:
+        # Delete temporary file
+        temp_path.unlink()
+
+
+@pytest.fixture
+def two_level_array():
+    M, N = 24, 16
+
+    x = np.linspace(0, M-1, M)
+    y = np.linspace(N-1, 0, N)
+
+    A = np.zeros((M, N))
+    for (i,j) in np.ndindex((M, N)):
+        A[i,j] = 2.0 if (y[j] > max(y)/2)  else  1.0
+
+    return A
+
+
+@pytest.fixture
+def random_array():
+    M, N = 24, 16
+
+    return np.random.randn(M, N)
+
+
+@pytest.fixture
+def upper_half_rectangle():
+    return Polygon.from_bounds(0, 8, 23, 15)
+
+
+def test_image_extents(two_level_array):
+    with image_from_array(two_level_array) as image:
+        extents = get_image_extents(image=image)
+        m, n = extents.shape
+
+        assert np.array(image).shape == (m, n)
+        assert (extents.x_min, extents.y_min) == (0, 0)
+        assert (extents.x_max, extents.y_max) == (m-1, n-1)
+
+
+def test_image_crop(two_level_array, upper_half_rectangle):
+    with image_from_array(two_level_array) as image:
+        M, N = two_level_array.shape
+        sub_image, extents = crop_image_to_polygon(image=image, polygon=upper_half_rectangle)
+        sub_array = np.array(sub_image)
+
+        # Check extents
+        assert extents.shape == (M, np.ceil(N/2))
+        assert extents.delta_x == extents.delta_y == 1
+        assert extents.x_min == 0
+        assert extents.x_max == M - 1
+        assert extents.y_min == np.floor(N / 2)
+        assert extents.y_max == N - 1
+
+        # Check contents
+        assert not (sub_array - 2.0).any()


### PR DESCRIPTION
This pull requests adds a mesh class.

Usage examples:
```
mesh = Mesh.from_raster(data=raster_data, domain=geo_polygon)

coarse_mesh = mesh.simplify(ratio=0.5, max_size=200)

points = mesh.points
faces = mesh.faces
normals = mesh.face_normals
```

The `points`, `faces` and `normals` properties return read-only Numpy arrays.


Som other minor improvements are also included, for example handling of polygons with holes.