### PR TITLE
Added xdmf meta file when storing tins

### DIFF
--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -2,6 +2,7 @@ from typing import Dict, Any
 import numpy as np
 from datetime import datetime
 from h5py import File
+from lxml import etree
 from pathlib import Path
 from rasputin.mesh import Mesh
 from rasputin.geometry import Geometry
@@ -52,24 +53,82 @@ class TinRepository:
             meta_info[f.stem] = self.info(uid=f.stem)
         return meta_info
 
-    def save(self, *, uid: str, geometries: Dict[str, Geometry], consolidate_mesh: bool=False) -> None:
-        filename = self.path / f"{uid}.h5"
-        if filename.exists():
+    def save(self, *, uid: str, geometries: Dict[str, Geometry]) -> None:
+        xdmf_filename = self.path / f"{uid}.xdmf"
+        h5_base = f"{uid}.h5"
+        h5_filename = self.path / h5_base
+        if h5_filename.exists():
             raise FileExistsError(f"Archive already has a data set with uid {uid}.")
-        with File(filename, "w") as archive:
-            archive.attrs["timestamp"] = datetime.utcnow().timestamp()
+        root = etree.XML('''\
+<?xml version="1.0" ?> 
+<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []> 
+<Xdmf Version="3.0"> 
+</Xdmf>''')
+        tree = etree.ElementTree(root)
+        domain = etree.SubElement(root, "Domain")
+
+        with File(h5_filename, "w") as archive:
+            timestamp = datetime.utcnow().timestamp()
+            archive.attrs["timestamp"] = timestamp
+            etree.SubElement(root,
+                             "Information",
+                             Name="timestamp",
+                             Value=str(timestamp))
             root_grp = archive.create_group("tins")
             for name, geom in geometries.items():
                 grp = root_grp.create_group(name)
-                if consolidate_mesh:
-                    points, faces = consolidate(geom.points, geom.faces)
-                else:
-                    points, faces = geom.points, geom.faces
-                h5_points = grp.create_dataset(name="points", data=np.asarray(points), dtype="d")
+                points, faces = geom.points, geom.faces
+                grid = etree.SubElement(domain, "Grid", Name=name)
+                x_geom = etree.SubElement(grid,
+                                        "Geometry",
+                                        GeometryType="XYZ")
+                pts_elm = etree.SubElement(x_geom,
+                                           "DataItem",
+                                           Format="HDF",
+                                           DataType="Float",
+                                           Precision="8",
+                                           Dimensions=f"{points.shape[0]} {points.shape[1]}")
+                pts_elm.text = f"{h5_base}:/tins/{name}/points"
+                topo = etree.SubElement(grid,
+                                        "Topology",
+                                        NumberOfElements=str(faces.shape[0]),
+                                        TopologyType="Triangle")
+                f_elm = etree.SubElement(topo,
+                                         "DataItem",
+                                         Format="HDF",
+                                         Precision="4",
+                                         DataType="Int",
+                                         Dimensions=f"{faces.shape[0]} {faces.shape[1]}")
+                attr = etree.SubElement(grid,
+                                        "Attribute",
+                                        Name="Color",
+                                        Center="Cell",
+                                        AttributeType="Vector")
+                attr_elm = etree.SubElement(attr,
+                                            "DataItem",
+                                            Format="HDF",
+                                            Precision="8",
+                                            DataType="Float",
+                                            Dimensions=f"{faces.shape[0]} 3")
+                attr_elm.text = f"{h5_base}:/tins/{name}/face_color"
+                etree.SubElement(pts_elm,
+                                 "Information",
+                                 Name="projection",
+                                 Value=geom.projection.definition_string())
+                f_elm.text = f"{h5_base}:/tins/{name}/faces"
+                h5_points = grp.create_dataset(name="points", data=points, dtype="d")
                 h5_points.attrs["projection"] = geom.projection.definition_string()
-                h5_faces = grp.create_dataset(name="faces", data=np.asarray(faces), dtype="i")
+                h5_faces = grp.create_dataset(name="faces", data=faces, dtype="i")
                 h5_faces.attrs["color"] = geom.base_color
+                color_arr = np.empty((len(faces), 3), dtype="float")
+                color_arr[:, 0] = geom.base_color[0]
+                color_arr[:, 1] = geom.base_color[1]
+                color_arr[:, 2] = geom.base_color[2]
+                grp.create_dataset(name="face_color", data=color_arr)
+        tree.write(str(xdmf_filename), encoding="utf-8")
+
 
     def delete(self, uid: str) -> None:
         if uid in self.content:
             (self.path / f"{uid}.h5").unlink()
+            (self.path / f"{uid}.xdmf").unlink()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -17,11 +17,12 @@ def raster():
     array = (zeros((m,n))
              + linspace(0, 1, m).reshape(-1,1)**2
              + linspace(0, 1, n).reshape(1,-1))
-    return Rasterdata(array=array.astype(float32),
+    return Rasterdata(shape=(m, n),
                       x_min=0,
                       y_max=1,
                       delta_x=1 / (m-1),
                       delta_y=1 / (n-1),
+                      array=array.astype(float32),
                       coordinate_system="+init=epsg:32633",
                       info={})
 
@@ -36,18 +37,20 @@ def raster_list():
     array1 = (zeros((m1,n1))
               + linspace(d1, 1, m1).reshape(-1,1)**2
               + linspace(0, 1, n1).reshape(1,-1))
-    return [Rasterdata(array=array0.astype(float32),
+    return [Rasterdata(shape=(m0, n0),
                        x_min=0,
                        y_max=1,
                        delta_x=d0 / (m0-1),
                        delta_y=1 / (n0-1),
+                       array=array0.astype(float32),
                        coordinate_system="+init=epsg:32633",
                        info={}),
-            Rasterdata(array=array1.astype(float32),
+            Rasterdata(shape=(m0, n0),
                        x_min=d1,
                        y_max=1,
                        delta_x=(1-d1) / (m1-1),
                        delta_y=1 / (n1-1),
+                       array=array1.astype(float32),
                        coordinate_system="+init=epsg:32633",
                        info={})]
 
@@ -99,7 +102,7 @@ def test_mesh(raster, polygon):
 
     # Check that all points in raster not inside polygon are not mesh
     def dist(mesh, pt):
-        return  norm(mesh.points[:,:2] - pt, axis=0).min()
+        return norm(mesh.points[:,:2] - pt, axis=0).min()
 
     for i, j in ndindex(raster.array.shape):
         x = raster.x_min + i * raster.delta_x
@@ -136,7 +139,7 @@ def test_mesh_w_hole(raster, polygon_w_hole):
 
     # Check that all points in raster not inside polygon are not mesh
     def dist(mesh, pt):
-        return  norm(mesh.points[:,:2] -pt, axis=0).min()
+        return norm(mesh.points[:,:2] -pt, axis=0).min()
 
     for i, j in ndindex(raster.array.shape):
         x = raster.x_min + i * raster.delta_x


### PR DESCRIPTION
This PR adds xdmf to the tin archive when storing tins. The effect of this is that visualisation software like paraview can render rasputin output directly. Also a color cell array is added to the hdf-file in terms of a vector field of rgb-values, which allows external software to visualise the land types with appropriate colors.