### PR TITLE
Proj4 upgrade

### DIFF
--- a/src/rasputin/avalanche.py
+++ b/src/rasputin/avalanche.py
@@ -16,10 +16,10 @@ varsom_angles = [( -22.5,  22.5),
                  ( -67.5, -22.5)]
 
 
-def get_forecasts(*, x: float, y: float, proj: str) -> Dict[str, Any]:
-    p_source = pyproj.Proj(proj)
-    p_target = pyproj.Proj("+init=epsg:4326")
-    lon, lat = pyproj.transform(p_source, p_target, x, y)
+def get_forecasts(*, x: float, y: float, crs: pyproj.CRS) -> Dict[str, Any]:
+    target_crs = pyproj.CRS.from_epsg(4326)
+    proj = pyproj.Transformer.from_crs(crs, target_crs)
+    lat, lon = proj.transform(x, y)
     lang = 1
     now = datetime.datetime.now()
     start = now.strftime("%Y-%m-%d")

--- a/src/rasputin/mesh_utils.py
+++ b/src/rasputin/mesh_utils.py
@@ -21,8 +21,8 @@ def face_field_to_vertex_values(*,
 
 def vertex_field_to_vertex_values(*,
                                   vertex_field: np.ndarray,
-                                  faces: td.face_vector,
-                                  points: td.point3_vector) -> np.ndarray:
+                                  faces: np.ndarray,
+                                  points: np.ndarray) -> np.ndarray:
     """
 
     :param field: color (vector) field over points

--- a/src/rasputin/reader.py
+++ b/src/rasputin/reader.py
@@ -145,7 +145,7 @@ class GeoKeysInterpreter(object):
 
         import pyproj
         proj_str = GeoKeyInterpreter(geokeys).to_proj4()
-        proj = pyproj.Proj(proj_str)
+        proj = pyproj.CRS.from_proj4(proj_str)
 
     NOTE:
     This class is incomplete and many GeoKeys are not handled. Extending the class with new handlers
@@ -312,6 +312,7 @@ class ImageExtents:
         assert len(self.shape) == 2 and min(*self.shape) > 0, "Shape is not two-dimensional."
         assert min(self.delta_x, self.delta_y) > 0, "Step sizes must be strictly positive."
 
+
 @dataclass
 class Rasterdata(ImageExtents):
     array: np.ndarray
@@ -326,7 +327,7 @@ class Rasterdata(ImageExtents):
     @property
     def polygon(self):
         return GeoPolygon(polygon=Polygon.from_bounds(*self.box),
-                          crs=pyproj.CRS.from_string(self.coordinate_system))
+                          crs=pyproj.CRS.from_proj4(self.coordinate_system))
 
     def to_cpp(self) -> triangulate_dem.raster_data_float:
         return triangulate_dem.raster_data_float(self.array,

--- a/src/rasputin/tin_repository.py
+++ b/src/rasputin/tin_repository.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from h5py import File
 from lxml import etree
 from pathlib import Path
+from pyproj import CRS
 from rasputin.mesh import Mesh
 from rasputin.geometry import Geometry
 
@@ -40,7 +41,7 @@ class TinRepository:
                 color = group["faces"].attrs["color"]
                 mesh = Mesh.from_points_and_faces(points=pts, faces=faces)
                 geometries[name] = Geometry(mesh=mesh,
-                                            projection=projection,
+                                            crs=CRS.from_proj4(projection),
                                             base_color=color,
                                             material=None)
         return geometries
@@ -114,10 +115,10 @@ class TinRepository:
                 etree.SubElement(pts_elm,
                                  "Information",
                                  Name="projection",
-                                 Value=geom.projection.definition_string())
+                                 Value=geom.crs.to_proj4())
                 f_elm.text = f"{h5_base}:/tins/{name}/faces"
                 h5_points = grp.create_dataset(name="points", data=points, dtype="d")
-                h5_points.attrs["projection"] = geom.projection.definition_string()
+                h5_points.attrs["projection"] = geom.crs.to_proj4()
                 h5_faces = grp.create_dataset(name="faces", data=faces, dtype="i")
                 h5_faces.attrs["color"] = geom.base_color
                 color_arr = np.empty((len(faces), 3), dtype="float")

--- a/src/rasputin/web_visualize.py
+++ b/src/rasputin/web_visualize.py
@@ -53,12 +53,12 @@ def depr_web_visualize():
     dx = res.dx
     dy = res.dy
 
-    input_coordinate_system = pyproj.Proj(init="EPSG:4326").definition_string()
-    target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
+    input_crs = pyproj.CRS.from_string("+init=EPSG:4326")
+    target_crs = pyproj.CRS.from_epsg(32633)
 
     avalanche_problems = []
     if res.a:
-        avalanche_details, avalanche_meta = avalanche.get_forecasts(x=x0, y=y0, proj=input_coordinate_system)
+        avalanche_details, avalanche_meta = avalanche.get_forecasts(x=x0, y=y0, crs=input_crs)
         if avalanche_details:
             if "AvalancheProblems" in avalanche_details:
                 level = int(avalanche_details["DangerLevel"])
@@ -87,6 +87,7 @@ def depr_web_visualize():
                     avalanche_problems.append({"expositions": expositions,
                                                "level": level,
                                                "heights": danger_interval})
+    raise DeprecationWarning("This code is deprecated!")
     raster_coords = RasterRepository(directory=data_dir).read(x=x0,
                                                               y=y0,
                                                               dx=dx,
@@ -159,8 +160,4 @@ cd {output}
 {Path(sys.executable).name} -m http.server 8080
 Then visit http://localhost:8080
 """)
-
-
-if __name__ == "__main__":
-    web_visualize()
 

--- a/tests/test_gml_repository.py
+++ b/tests/test_gml_repository.py
@@ -16,14 +16,14 @@ def test_gml_repository():
     if "RASPUTIN_DATA_DIR" not in os.environ:
         raise RuntimeError("Please set RASPUTIN_DATA_DIR")
     path = Path(os.environ["RASPUTIN_DATA_DIR"]) / "corine"
-    input_coordinate_system = pyproj.Proj(init="EPSG:4326")
-    target_coordinate_system = pyproj.Proj(init="EPSG:32633")
+    input_crs = pyproj.CRS.from_string("+init=EPSG:4326")
+    target_crs = pyproj.CRS.from_epsg(32633)
 
     x = np.array([8.5, 8.52, 8.52, 8.5])
     y = np.array([60.55, 60.55, 60.50, 60.50])
 
-    x, y = pyproj.transform(input_coordinate_system, target_coordinate_system, x, y)
-    domain = GeoPolygon(polygon=Polygon(shell=list(zip(x, y))), projection=target_coordinate_system)
+    x, y = pyproj.Transformer.from_crs(input_crs, target_crs).transform(x, y)
+    domain = GeoPolygon(polygon=Polygon(shell=list(zip(x, y))), crs=target_crs)
 
     repos = GMLRepository(path=path)
     plot = False
@@ -41,12 +41,11 @@ def test_gml_repository():
 
     dem_archive = Path(os.environ["RASPUTIN_DATA_DIR"]) / "dem_archive"
     rr = RasterRepository(directory=dem_archive)
-    raster_domain = domain.transform(target_projection=pyproj.Proj(rr.coordinate_system(domain=domain)))
+    raster_domain = domain.transform(target_crs=pyproj.CRS.from_proj4(rr.coordinate_system(domain=domain)))
     raster_data_list = rr.read(domain=raster_domain)
     mesh = Mesh.from_raster(data=raster_data_list, domain=raster_domain)
 
     cmesh = mesh.simplify(ratio=0.1)
-    geo_cell_centers = GeoPoints(xy=cmesh.cell_centers[:, :2],
-                                 projection=target_coordinate_system)
+    geo_cell_centers = GeoPoints(xy=cmesh.cell_centers[:, :2], crs=target_crs)
     terrain_cover = repos.land_cover(land_types=None, geo_points=geo_cell_centers, domain=domain)
     assert terrain_cover is not None

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,9 +1,8 @@
 import pytest
 from numpy import array, cos, sin, linspace, pi, float32, zeros, ndindex
-from numpy.random import rand, randn
 from numpy.linalg import norm
 
-from pyproj import Proj
+import pyproj
 from shapely.geometry import Polygon, Point
 
 from rasputin.geometry import GeoPolygon
@@ -61,13 +60,13 @@ def polygon():
     x, y = array([0.51, 0.5])
     r = 0.4
 
-    cs = "+init=epsg:32633"
+    epsg_id = 32633
 
     polygon = Polygon([(x + r*cos(t), y + r*sin(t))
                       for t in linspace(0, 2*pi, N+1)[:-1]])
 
     return GeoPolygon(polygon=polygon,
-                      projection=Proj(cs))
+                      crs=pyproj.CRS.from_epsg(epsg_id))
 
 @pytest.fixture
 def polygon_w_hole():
@@ -76,7 +75,7 @@ def polygon_w_hole():
     x, y = array([0.51, 0.5])
     r1, r2 = 0.4, 0.25
 
-    cs = "+init=epsg:32633"
+    epsg_id = 32633
 
     polygon_1 = Polygon((x + r1*cos(t), y + r1*sin(t))
                         for t in linspace(0, 2*pi, N1+1)[:-1])
@@ -85,7 +84,7 @@ def polygon_w_hole():
                         for t in linspace(0, 2*pi, N2+1)[:-1])
 
     return GeoPolygon(polygon=polygon_1.difference(polygon_2),
-                      projection=Proj(cs))
+                      crs=pyproj.CRS.from_epsg(epsg_id))
 
 def test_mesh(raster, polygon):
     mesh = Mesh.from_raster(data=raster, domain=polygon)

--- a/tests/test_raster_repository.py
+++ b/tests/test_raster_repository.py
@@ -14,9 +14,8 @@ def test_get():
     x0 = 8.54758671814368
     y0 = 60.898468
     repo = RasterRepository(directory=Path(data_dir) / "dem_archive")
-    input_coordinate_system = pyproj.Proj(init="EPSG:4326")
-    #target_coordinate_system = pyproj.Proj(init="EPSG:32633").definition_string()
+    input_crs = pyproj.CRS.from_string("+init=EPSG:4326")
     polygon = Polygon.from_bounds(xmin=x0 - 0.1, xmax=x0 + 0.1, ymin=y0 - 0.1, ymax=y0 + 0.1)
-    geo_polygon = GeoPolygon(projection=input_coordinate_system, polygon=polygon)
+    geo_polygon = GeoPolygon(crs=input_crs, polygon=polygon)
     result = repo.read(domain=geo_polygon)
     assert result

--- a/tests/test_tin_repository.py
+++ b/tests/test_tin_repository.py
@@ -5,7 +5,7 @@ import numpy as np
 from rasputin.tin_repository import TinRepository
 from rasputin.mesh import Mesh
 from rasputin.geometry import Geometry
-from pyproj import Proj
+from pyproj import CRS
 
 @pytest.fixture
 def tin():
@@ -17,11 +17,11 @@ def tin():
 def test_store_tin(tin):
     pts, faces = tin
     uid = "test_tin"
-    proj = Proj(init="EPSG:32633")
+    crs = CRS.from_epsg(32633)
     geom_tag = "test_geom"
     mesh = Mesh.from_points_and_faces(points=pts, faces=faces)
     geom = {geom_tag: Geometry(mesh=mesh,
-                               projection=proj,
+                               crs=crs,
                                base_color=(0, 0, 0),
                                material="dummy2")}
     with TemporaryDirectory() as directory:
@@ -40,10 +40,10 @@ def test_store_tin(tin):
 def test_store_and_load_tin(tin):
     pts, faces = tin
     uid = "test_tin"
-    proj = Proj(init="EPSG:32633")
+    crs = CRS(32633)
     mesh = Mesh.from_points_and_faces(points=pts, faces=faces)
     geom = {"test_geom": Geometry(mesh=mesh,
-                                  projection=proj,
+                                  crs=crs,
                                   base_color=(0,0,0),
                                   material="dummy2")}
     with TemporaryDirectory() as directory:
@@ -58,10 +58,10 @@ def test_store_and_load_tin(tin):
 def test_store_and_delete_tin(tin):
     pts, faces = tin
     uid = "test_tin"
-    proj = Proj(init="EPSG:32633")
+    crs = CRS.from_epsg(32633)
     mesh = Mesh.from_points_and_faces(points=pts, faces=faces)
     geom = {"test_geom": Geometry(mesh=mesh,
-                                  projection=proj,
+                                  crs=crs,
                                   base_color=(0,0,0),
                                   material="dummy2")}
     with TemporaryDirectory() as directory:


### PR DESCRIPTION
This PR changes the soon deprecated `pyproj.transform` and `pyproj.Proj` by `pyproj.Transformer` and `pyproj.CRS` according to the 2.1 version of `pyproj`. Tests are updated accordingly and run as expected.