### PR TITLE
Build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ else()
     find_package(pybind11 REQUIRED)
 endif()
 
-
 # Boost::geometry
 # ---------------
 if (EXISTS "${RASPUTIN_LIB_DIR}/geometry")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,27 +26,15 @@ set(RASPUTIN_DEPENDENCIES) # Append to list as they are found
 
 # Pybind11
 # --------
-if (EXISTS "${RASPUTIN_LIB_DIR}/pybind11")
-    add_subdirectory("${RASPUTIN_LIB_DIR}/pybind11")
-else()
-    find_package(pybind11 REQUIRED)
-endif()
+find_package(pybind11 REQUIRED)
 
 # Boost::geometry
 # ---------------
-if (EXISTS "${RASPUTIN_LIB_DIR}/geometry")
-    add_library(geometry INTERFACE)
-    target_include_directories(geometry PRIVATE INTERFACE
-        "${RASPUTIN_LIB_DIR}/geometry/include")
-    list(APPEND RASPUTIN_DEPENDENCIES geometry)
-    add_definitions(-DHAS_BOOST)
-else()
-    find_package(Boost REQUIRED)
-    # Import into scope
-    add_library(Boost::geometry INTERFACE IMPORTED)
-    list(APPEND RASPUTIN_DEPENDENCIES Boost::geometry)
-    add_definitions(-DHAS_BOOST)
-endif()
+find_package(Boost REQUIRED)
+# Import into scope
+add_library(Boost::geometry INTERFACE IMPORTED)
+list(APPEND RASPUTIN_DEPENDENCIES Boost::geometry)
+add_definitions(-DHAS_BOOST)
 
 
 # date
@@ -66,7 +54,6 @@ list(APPEND RASPUTIN_DEPENDENCIES date)
 # CGAL
 # ----
 # Required for now but should be optional in the future
-set(CMAKE_PREFIX_PATH  "${RASPUTIN_LIB_DIR}/cgal" ${CMAKE_PREFIX_PATH})
 find_package(CGAL REQUIRED)
 if (CGAL_FOUND)
     add_definitions(-DHAS_CGAL) # For future use when CGAL is optional
@@ -79,12 +66,7 @@ endif()
 
 # Armadillo
 # ---------
-if (EXISTS "${RASPUTIN_LIB_DIR}/armadillo")
-    set(ARMADILLO_INCLUDE_DIRS "${RASPUTIN_LIB_DIR}/armadillo/include")
-else()
-    # NOTE: This fails if the wrapper library is not found
-    find_package(Armadillo REQUIRED)
-endif()
+find_package(Armadillo REQUIRED)
 add_library(Armadillo INTERFACE)
 target_include_directories(Armadillo PRIVATE INTERFACE
     ${ARMADILLO_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -27,17 +27,20 @@ The heavy lifting in Rasputin is done by external software:
 
 ## Installation
 
-Installing Rasputin is easy, as the C++ dependencies are header only. Simply clone the source repository for each dependency into the `lib` directory.
-For examaple, from the Rasputin respotory root, run the following commands:
+Installing Rasputin is easy, as the C++ dependencies are header only. Simply, either install the dependencies using your system's package manager, or clone the source repository for each dependency locally on your computer and install them in such a way that CMake will find them.
+For examaple, in some location where you have your source code, type:
 
 ```
+git clone https://github.com/pybind/pybind11.git 
+git clone https://gitlab.com/conradsnicta/armadillo-code.git 
+git clone https://github.com/boostorg/geometry.git 
+git clone https://github.com/catchorg/Catch2.git 
+git clone https://github.com/CGAL/cgal.git 
+```
+For Howard Hinnant's `date` library to work, enter the rasputin source root directory and checkout the source under the `lib` folder:
+```
 cd lib
-git clone https://github.com/pybind/pybind11.git --branch=v2.4.3
-git clone https://gitlab.com/conradsnicta/armadillo-code.git --branch=9.800.x armadillo
-git clone https://github.com/boostorg/geometry.git --branch=boost-1.71.0
-git clone https://github.com/HowardHinnant/date.git --branch=v2.4.1
-git clone https://github.com/catchorg/Catch2.git --branch=v2.10.2 catch2
-git clone https://github.com/CGAL/cgal.git --branch=releases/CGAL-5.0 cgal
+git clone https://github.com/HowardHinnant/date.git 
 ```
 
 Rasputin does not aim at being backwards compatible with older compilers.

--- a/cpp_test/CMakeLists.txt
+++ b/cpp_test/CMakeLists.txt
@@ -2,27 +2,9 @@ enable_testing()
 
 # Find Catch2
 # -----------
-
-# First look under lib/Catch2
-if (EXISTS "${RASPUTIN_LIB_DIR}/catch2")
-    include("${RASPUTIN_LIB_DIR}/catch2/contrib/Catch.cmake")
-    include(CTest)
-    add_library(Catch2 INTERFACE)
-    target_include_directories(Catch2 INTERFACE
-        "${RASPUTIN_LIB_DIR}/catch2/single_include")
-    set(catchlib Catch2)
-
-# Otherwise look for catch2 installed on system
-else()
-    find_package(Catch2 REQUIRED)
-    set(catchlib Catch2::Catch2)
-    include(Catch)
-    include(CTest)
-endif()
+find_package(Catch2 3 REQUIRED)
 
 # Build tests
 # -----------
-add_executable(rasputin_test test_sun_position.cpp)
-target_link_libraries(rasputin_test rasputin ${catchlib} ${RASPUTIN_DEPENDENCIES})
-
-catch_discover_tests(rasputin_test)
+add_executable(test_sun_position test_sun_position.cpp)
+target_link_libraries(test_sun_position PRIVATE rasputin Catch2::Catch2WithMain ${RASPUTIN_DEPENDENCIES})

--- a/cpp_test/test_sun_position.cpp
+++ b/cpp_test/test_sun_position.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include <catch2/catch.hpp>
+//#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <solar_position.h>
 #include <cmath>
 #ifndef __clang__


### PR DESCRIPTION
Change build regime from assuming source code under `rasputin_root_dir/lib` to rely on the default CMake behaviour and `find_package`. Documentation updated, and minor adjustments for Catch2 dep.